### PR TITLE
Add detect_numa script

### DIFF
--- a/.github/workflows/generic_test.yml
+++ b/.github/workflows/generic_test.yml
@@ -1,0 +1,19 @@
+on: push
+
+jobs:
+  generic_test_run:
+    strategy:
+      matrix:
+        image: [ ubuntu:focal, registry.access.redhat.com/ubi8/python-39:1-126, registry.access.redhat.com/ubi9/python-39:1-125]
+        test: [tests/test_detect_numa]
+    runs-on: ubuntu-22.04
+    container:
+      image: ${{ matrix.image }}
+      options: --user 0
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+      - name: Run tests
+        run: ./${{ matrix.test }}
+
+  

--- a/.github/workflows/generic_test.yml
+++ b/.github/workflows/generic_test.yml
@@ -4,8 +4,12 @@ jobs:
   generic_test_run:
     strategy:
       matrix:
-        image: [ ubuntu:focal, registry.access.redhat.com/ubi8/python-39:1-126, registry.access.redhat.com/ubi9/python-39:1-125]
-        test: [tests/test_detect_numa]
+        image: 
+          - "ubuntu:focal"
+          - "registry.access.redhat.com/ubi8/python-39:1-126"
+          - "registry.access.redhat.com/ubi9/python-39:1-125"
+        test:
+          - tests/test_detect_numa
     runs-on: ubuntu-22.04
     container:
       image: ${{ matrix.image }}

--- a/README
+++ b/README
@@ -30,3 +30,4 @@ pull_data:  Process the csv data for the tests.
 set_pbench_variables
 umount_filesystems: unmounts a series of filesystems.
 detect_os: Determines the currently running OS
+detect_numa: Allows fetching NUMA information on a system

--- a/detect_numa
+++ b/detect_numa
@@ -1,0 +1,122 @@
+#!/bin/bash
+
+get_nodes=0
+get_cpus=0
+node=""
+
+usage()
+{
+    echo -e "$0"
+    echo -e "Fetches NUMA information, such as the number of NUMA nodes, which nodes have what CPUs, etc"
+
+    echo -e "\t-h/--help/--usage"
+    echo -e "\t\tShow this help message"
+
+    echo -e "\t--node-count"
+    echo -e "\t\tDisplay the number of NUMA nodes on the system (default operation)"
+    echo -e "\t\t\tCannot be used with --cpu-list"
+
+    echo -e "\t--cpu-list"
+    echo -e "\t\tList the CPUs on all NUMA nodes if -n/--node-count is not specified"
+    echo -e "\t\t\tCannot be used with --node-count"
+
+    echo -e "\t-n/--node"
+    echo -e "\t\tRestrict CPUs listed by --cpu-list to certain nodes"
+    echo -e "\t\t\tSupports ranges (0-5), comma separated values (0,2,4), and single digits (1)"
+    exit 0
+}
+
+# Fetches the number of NUMA nodes
+get_num_nodes()
+{
+    local numa_nodes=`lscpu | grep NUMA | grep CPU | wc -l`
+    if [ -z "$numa_nodes" ] || [ $numa_nodes -le 0 ]; then
+        numa_nodes=1
+    fi
+
+    echo $numa_nodes
+}
+
+#Fetches the CPUs on a NUMA node, if nothing is supplied all CPUs are returned grouped by their node
+fetch_cpus() {
+    local node=$1
+    local node_count=`get_num_nodes`    
+    if [ -z "$node" ]; then # Used to filter out "NUMA node(s)" line
+        node="[0-9]+"
+    elif ! echo "$node" | grep -Eq "^[0-9]+$"; then # If node is not in numerical format, it must be range/comma separated
+        node=`echo "[$node]" | sed -e 's/,/|/g'`
+    elif [ $node -gt $((node_count-1)) ]; then #If a single integer is provided, verify it's within bounds
+        echo "Error: NUMA Node $node does not exist" > /dev/stderr
+        exit 1
+    fi
+    lscpu | grep -E "NUMA node$node" | sort | awk '{ print $4 }'
+}
+
+NOARG_OPTS=(
+    "h"
+    "help"
+    "usage"
+
+    "cpu-list"
+    "list-cpu"
+    "node-count"
+)
+
+ARG_OPTS=(
+    "node"
+    "n"
+)
+
+opts=$(getopt \
+    --longoptions "$(printf "%s," "${NOARG_OPTS[@]}")" \
+    --longoptions "$(printf "%s:," "${ARG_OPTS[@]}")" \
+    --name "$(basename "$0")" \
+    --options "hn:" \
+    -- "$@"
+)
+
+if [ $? -ne 0 ]; then
+        exit 1
+fi
+
+eval set --$opts
+
+while [[ $# -gt 0 ]]; do
+	case "$1" in
+    -h | --usage | --help)
+        usage
+    ;;
+    -n | --node)
+        node=$2
+        shift 2
+    ;;
+    --list-cpu | --cpu-list)
+        get_cpus=1
+        shift 1
+    ;;
+    -n | --node-count)
+        get_nodes=1
+        shift 1
+    ;;
+    --)
+        break
+    ;;
+    *)
+        echo_stderr Unknown option $1
+        exit 1
+    ;;
+    esac
+done
+
+if [ $get_nodes -eq 1 ] && [ $get_cpus -eq 1 ];then
+    usage
+fi
+
+# Get nodes by default if nothing is specified
+if [ $get_nodes -eq 1 ] || [ $get_cpus -eq $get_nodes ]; then
+    get_num_nodes
+else
+    fetch_cpus $node
+fi
+
+exit 0

--- a/detect_numa
+++ b/detect_numa
@@ -32,8 +32,9 @@ has_numa()
     local numa_nodes=`lscpu | grep NUMA | grep CPU | wc -l`
     if [ -z "$numa_nodes" ] || [ $numa_nodes -le 0 ]; then
         echo 0
+    else
+        echo 1
     fi
-    echo 1
 }
 
 # Fetches the number of NUMA nodes

--- a/detect_numa
+++ b/detect_numa
@@ -26,11 +26,21 @@ usage()
     exit 0
 }
 
+# Verifies that NUMA exists on the system
+has_numa()
+{
+    local numa_nodes=`lscpu | grep NUMA | grep CPU | wc -l`
+    if [ -z "$numa_nodes" ] || [ $numa_nodes -le 0 ]; then
+        echo 0
+    fi
+    echo 1
+}
+
 # Fetches the number of NUMA nodes
 get_num_nodes()
 {
     local numa_nodes=`lscpu | grep NUMA | grep CPU | wc -l`
-    if [ -z "$numa_nodes" ] || [ $numa_nodes -le 0 ]; then
+    if [ "`has_numa`" -eq 0 ]; then
         numa_nodes=1
     fi
 
@@ -40,8 +50,13 @@ get_num_nodes()
 #Fetches the CPUs on a NUMA node, if nothing is supplied all CPUs are returned grouped by their node
 fetch_cpus() {
     local node=$1
-    local node_count=`get_num_nodes`    
-    if [ -z "$node" ]; then # Used to filter out "NUMA node(s)" line
+    local node_count=`get_num_nodes`
+    local prefix="NUMA node"
+
+    if [ `has_numa` -eq 0 ]; then # Return all syste
+        prefix="On-line CPU\(s\) list:"
+        node=""
+    elif [ -z "$node" ]; then # Used to filter out "NUMA node(s)" line
         node="[0-9]+"
     elif ! echo "$node" | grep -Eq "^(-)?[0-9]+$"; then # If node is not in numerical format, it must be range/comma separated
         node=`echo "[$node]" | sed -e 's/,/|/g'`
@@ -49,7 +64,7 @@ fetch_cpus() {
         echo "Error: NUMA Node $node does not exist" > /dev/stderr
         exit 1
     fi
-    lscpu | grep -E "NUMA node$node" | sort | awk '{ print $4 }'
+    lscpu | grep -E "$prefix$node" | sort | awk '{ print $4 }'
 }
 
 NOARG_OPTS=(

--- a/detect_numa
+++ b/detect_numa
@@ -43,9 +43,9 @@ fetch_cpus() {
     local node_count=`get_num_nodes`    
     if [ -z "$node" ]; then # Used to filter out "NUMA node(s)" line
         node="[0-9]+"
-    elif ! echo "$node" | grep -Eq "^[0-9]+$"; then # If node is not in numerical format, it must be range/comma separated
+    elif ! echo "$node" | grep -Eq "^(-)?[0-9]+$"; then # If node is not in numerical format, it must be range/comma separated
         node=`echo "[$node]" | sed -e 's/,/|/g'`
-    elif [ $node -gt $((node_count-1)) ]; then #If a single integer is provided, verify it's within bounds
+    elif [ $node -gt $((node_count-1)) ] || [ $node -lt 0 ]; then #If a single integer is provided, verify it's within bounds
         echo "Error: NUMA Node $node does not exist" > /dev/stderr
         exit 1
     fi

--- a/tests/assert.sh
+++ b/tests/assert.sh
@@ -1,0 +1,186 @@
+#!/bin/bash
+# assert.sh 1.1 - bash unit testing framework
+# Copyright (C) 2009-2015 Robert Lehmann
+#
+# http://github.com/lehmannro/assert.sh
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Lesser General Public License as published
+# by the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU Lesser General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+export DISCOVERONLY=${DISCOVERONLY:-}
+export DEBUG=${DEBUG:-}
+export STOP=${STOP:-}
+export INVARIANT=${INVARIANT:-}
+export CONTINUE=${CONTINUE:-}
+
+args="$(getopt -n "$0" -l \
+    verbose,help,stop,discover,invariant,continue vhxdic $*)" \
+|| exit -1
+for arg in $args; do
+    case "$arg" in
+        -h)
+            echo "$0 [-vxidc]" \
+                "[--verbose] [--stop] [--invariant] [--discover] [--continue]"
+            echo "`sed 's/./ /g' <<< "$0"` [-h] [--help]"
+            exit 0;;
+        --help)
+            cat <<EOF
+Usage: $0 [options]
+Language-agnostic unit tests for subprocesses.
+
+Options:
+  -v, --verbose    generate output for every individual test case
+  -x, --stop       stop running tests after the first failure
+  -i, --invariant  do not measure timings to remain invariant between runs
+  -d, --discover   collect test suites only, do not run any tests
+  -c, --continue   do not modify exit code to test suite status
+  -h               show brief usage information and exit
+  --help           show this help message and exit
+EOF
+            exit 0;;
+        -v|--verbose)
+            DEBUG=1;;
+        -x|--stop)
+            STOP=1;;
+        -i|--invariant)
+            INVARIANT=1;;
+        -d|--discover)
+            DISCOVERONLY=1;;
+        -c|--continue)
+            CONTINUE=1;;
+    esac
+done
+
+_indent=$'\n\t' # local format helper
+
+_assert_reset() {
+    tests_ran=0
+    tests_failed=0
+    tests_errors=()
+    tests_starttime="$(date +%s%N)" # nanoseconds_since_epoch
+}
+
+assert_end() {
+    # assert_end [suite ..]
+    tests_endtime="$(date +%s%N)"
+    # required visible decimal place for seconds (leading zeros if needed)
+    local tests_time="$( \
+        printf "%010d" "$(( ${tests_endtime/%N/000000000} 
+                            - ${tests_starttime/%N/000000000} ))")"  # in ns
+    tests="$tests_ran ${*:+$* }tests"
+    [[ -n "$DISCOVERONLY" ]] && echo "collected $tests." && _assert_reset && return
+    [[ -n "$DEBUG" ]] && echo
+    # to get report_time split tests_time on 2 substrings:
+    #   ${tests_time:0:${#tests_time}-9} - seconds
+    #   ${tests_time:${#tests_time}-9:3} - milliseconds
+    [[ -z "$INVARIANT" ]] \
+        && report_time=" in ${tests_time:0:${#tests_time}-9}.${tests_time:${#tests_time}-9:3}s" \
+        || report_time=
+
+    if [[ "$tests_failed" -eq 0 ]]; then
+        echo "all $tests passed$report_time."
+    else
+        for error in "${tests_errors[@]}"; do echo "$error"; done
+        echo "$tests_failed of $tests failed$report_time."
+    fi
+    tests_failed_previous=$tests_failed
+    [[ $tests_failed -gt 0 ]] && tests_suite_status=1
+    _assert_reset
+}
+
+assert() {
+    # assert <command> <expected stdout> [stdin]
+    (( tests_ran++ )) || :
+    [[ -z "$DISCOVERONLY" ]] || return
+    expected=$(echo -ne "${2:-}")
+    result="$(eval 2>/dev/null $1 <<< ${3:-})" || true
+    if [[ "$result" == "$expected" ]]; then
+        [[ -z "$DEBUG" ]] || echo -n .
+        return
+    fi
+    result="$(sed -e :a -e '$!N;s/\n/\\n/;ta' <<< "$result")"
+    [[ -z "$result" ]] && result="nothing" || result="\"$result\""
+    [[ -z "$2" ]] && expected="nothing" || expected="\"$2\""
+    _assert_fail "expected $expected${_indent}got $result" "$1" "$3"
+}
+
+assert_raises() {
+    # assert_raises <command> <expected code> [stdin]
+    (( tests_ran++ )) || :
+    [[ -z "$DISCOVERONLY" ]] || return
+    status=0
+    (eval $1 <<< ${3:-}) > /dev/null 2>&1 || status=$?
+    expected=${2:-0}
+    if [[ "$status" -eq "$expected" ]]; then
+        [[ -z "$DEBUG" ]] || echo -n .
+        return
+    fi
+    _assert_fail "program terminated with code $status instead of $expected" "$1" "$3"
+}
+
+_assert_fail() {
+    # _assert_fail <failure> <command> <stdin>
+    [[ -n "$DEBUG" ]] && echo -n X
+    report="test #$tests_ran \"$2${3:+ <<< $3}\" failed:${_indent}$1"
+    if [[ -n "$STOP" ]]; then
+        [[ -n "$DEBUG" ]] && echo
+        echo "$report"
+        exit 1
+    fi
+    tests_errors[$tests_failed]="$report"
+    (( tests_failed++ )) || :
+}
+
+skip_if() {
+    # skip_if <command ..>
+    (eval $@) > /dev/null 2>&1 && status=0 || status=$?
+    [[ "$status" -eq 0 ]] || return
+    skip
+}
+
+skip() {
+    # skip  (no arguments)
+    shopt -q extdebug && tests_extdebug=0 || tests_extdebug=1
+    shopt -q -o errexit && tests_errexit=0 || tests_errexit=1
+    # enable extdebug so returning 1 in a DEBUG trap handler skips next command
+    shopt -s extdebug
+    # disable errexit (set -e) so we can safely return 1 without causing exit
+    set +o errexit
+    tests_trapped=0
+    trap _skip DEBUG
+}
+_skip() {
+    if [[ $tests_trapped -eq 0 ]]; then
+        # DEBUG trap for command we want to skip.  Do not remove the handler
+        # yet because *after* the command we need to reset extdebug/errexit (in
+        # another DEBUG trap.)
+        tests_trapped=1
+        [[ -z "$DEBUG" ]] || echo -n s
+        return 1
+    else
+        trap - DEBUG
+        [[ $tests_extdebug -eq 0 ]] || shopt -u extdebug
+        [[ $tests_errexit -eq 1 ]] || set -o errexit
+        return 0
+    fi
+}
+
+
+_assert_reset
+: ${tests_suite_status:=0}  # remember if any of the tests failed so far
+_assert_cleanup() {
+    local status=$?
+    # modify exit code if it's not already non-zero
+    [[ $status -eq 0 && -z $CONTINUE ]] && exit $tests_suite_status
+}
+trap _assert_cleanup EXIT

--- a/tests/test_detect_numa
+++ b/tests/test_detect_numa
@@ -1,52 +1,21 @@
 #!/bin/bash
 
-echo_stderr()
-{
-    echo ${@:1} > /dev/stderr
-    exit 1
-}
-
-test_cmd()
-{
-    local name=$1
-    local command=$2
-    local expected=$3
-    local failed=0
-
-    echo -n "$name... "
-    local actual=`$command`
-
-    if echo "$expected" | grep -Eq "^[0-9]+$"; then
-        if [ $expected -ne $actual ]; then
-            failed=1
-        fi
-    else
-        if [ $expected != $actual ]; then
-            failed=1
-        fi
-    fi
-
-    if [ $failed -eq 1 ]; then
-        echo "Failed"
-        echo_stderr "Expected $expected, got $actual"
-    fi
-    echo "Success"
-}
-
 exec_file="./detect_numa"
 num_nodes=`lscpu | grep "NUMA node(s)" | grep -Eo "[0-9]+"`
 cpu_node=`lscpu | grep -E "NUMA node[0-9]+" | awk '{ print $NF }'`
 
-echo "Start detect_numa tests"
-test_cmd "Test Default Behavior" "$exec_file" $num_nodes
+source "./tests/assert.sh"
 
-test_cmd "Test behavior with --node-count flag" "$exec_file --node-count" $num_nodes
+# Test Default behavior to output number of NUMA nodes
+assert "$exec_file" "$num_nodes"
 
-test_cmd "Test behavior with --cpu-list flag" "$exec_file --cpu-list" $cpu_node
+# Test --node-count flag
+assert "$exec_file --node-count" "$num_nodes"
 
-echo "Test behavior with invalid --node value... "
-if $exec_file --node 9999 --cpu-list > /dev/null 2>&1; then
-    echo "Failed"
-    echo_stderr "Program returned 0, while expected was non-zero" 
-fi
-echo "Success"
+# Test --cpu-list flag outputs CPUs grouped by NUMA node
+assert "$exec_file --cpu-list" $cpu_node
+
+# Ensure that the --node flag fails when a NUMA node does not exist
+assert_raises "$exec_file --node 9999 --cpu-list" 1
+
+assert_end

--- a/tests/test_detect_numa
+++ b/tests/test_detect_numa
@@ -1,0 +1,52 @@
+#!/bin/bash
+
+echo_stderr()
+{
+    echo ${@:1} > /dev/stderr
+    exit 1
+}
+
+test_cmd()
+{
+    local name=$1
+    local command=$2
+    local expected=$3
+    local failed=0
+
+    echo -n "$name... "
+    local actual=`$command`
+
+    if echo "$expected" | grep -Eq "^[0-9]+$"; then
+        if [ $expected -ne $actual ]; then
+            failed=1
+        fi
+    else
+        if [ $expected != $actual ]; then
+            failed=1
+        fi
+    fi
+
+    if [ $failed -eq 1 ]; then
+        echo "Failed"
+        echo_stderr "Expected $expected, got $actual"
+    fi
+    echo "Success"
+}
+
+exec_file="./detect_numa"
+num_nodes=`lscpu | grep "NUMA node(s)" | grep -Eo "[0-9]+"`
+cpu_node=`lscpu | grep -E "NUMA node[0-9]+" | awk '{ print $NF }'`
+
+echo "Start detect_numa tests"
+test_cmd "Test Default Behavior" "$exec_file" $num_nodes
+
+test_cmd "Test behavior with --node-count flag" "$exec_file --node-count" $num_nodes
+
+test_cmd "Test behavior with --cpu-list flag" "$exec_file --cpu-list" $cpu_node
+
+echo "Test behavior with invalid --node value... "
+if $exec_file --node 9999 --cpu-list > /dev/null 2>&1; then
+    echo "Failed"
+    echo_stderr "Program returned 0, while expected was non-zero" 
+fi
+echo "Success"

--- a/tests/test_detect_numa
+++ b/tests/test_detect_numa
@@ -3,6 +3,7 @@
 exec_file="./detect_numa"
 num_nodes=`lscpu | grep "NUMA node(s)" | grep -Eo "[0-9]+"`
 cpu_node=`lscpu | grep -E "NUMA node[0-9]+" | awk '{ print $NF }'`
+cpu_node_array=(${cpu_node//$'\n'/ })
 
 source "./tests/assert.sh"
 
@@ -15,7 +16,15 @@ assert "$exec_file --node-count" "$num_nodes"
 # Test --cpu-list flag outputs CPUs grouped by NUMA node
 assert "$exec_file --cpu-list" $cpu_node
 
-# Ensure that the --node flag fails when a NUMA node does not exist
-assert_raises "$exec_file --node 9999 --cpu-list" 1
+# Verify that the reported cpus belong to the correct NUMA node
+for i in `seq 0 $((num_nodes-1))`; do
+    assert "$exec_file --cpu-list --node $i" ${cpu_node_array[i]}
+done
+
+# Ensure that the --node flag fails when a NUMA node does not exist 
+assert_raises "$exec_file --node $((num_nodes)) --cpu-list" 1 # num_nodes is invalid since NUMA indexes from 0
+
+# Ensure that the --node flag fails when a negative NUMA node is provided
+assert_raises "$exec_file --node -1 --cpu-list" 1
 
 assert_end


### PR DESCRIPTION
This PR introduces `detect_numa` to fetch NUMA information, allowing scripts to get NUMA information in the same way.

This also adds tests for `detect_numa`, using a generic workflow, allowing easy expansion later on.