### PR TITLE
Need a unique pbench results directory name.

### DIFF
--- a/execute_via_pbench
+++ b/execute_via_pbench
@@ -159,7 +159,7 @@ echo $times_to_run > ./iteration.lis
 #
 # Assign the pbench args to a varaible, no duplication that way.
 #
-pbench_args="-C ${puser}_${test_name}_test --iteration-list=./iteration.lis --tool-group=${pbench_stats} -- ${cmd_executing} ${cmd_options}"
+pbench_args="-C ${puser}_${test_name}_test__${configuration} --iteration-list=./iteration.lis --tool-group=${pbench_stats} -- ${cmd_executing} ${cmd_options}"
 pbench-user-benchmark $pbench_args
 if [ $? -ne 0 ]; then
 	echo pbench-user-benchmark $pbench_args


### PR DESCRIPTION
There is an issue where we have multiple running workloads, even with timestamps we can get the same pbench results directory name.  When we save the results, pbench gets all confused and will only give us the first result s.  To fix this, we are adding the instance size to the pbench results area (in case of baremetal, will be the hosts name).  This does not take care of the issue of the user running multiple same test across multiple same VM  sizes.  We are avoiding that because it will require a change in all the scripts, and the pbench folks will resolve this issue in the future.