### PR TITLE
Fix misleading error message.

### DIFF
--- a/grab_disks
+++ b/grab_disks
@@ -89,7 +89,7 @@ fi
 # to make sure the disk exist.
 #
 if [ $numb_disks -eq 0 ]; then
-	echo  "Need to have disks to perform disks, non provided."
+	echo  "Need to have disks to perform disks, none provided."
 	exit 1
 fi
 echo  $disks:$numb_disks

--- a/grab_disks
+++ b/grab_disks
@@ -89,7 +89,7 @@ fi
 # to make sure the disk exist.
 #
 if [ $numb_disks -eq 0 ]; then
-	echo  "Need to have disks to perform desks, non provided."
+	echo  "Need to have disks to perform disks, non provided."
 	exit 1
 fi
 echo  $disks:$numb_disks

--- a/grab_disks
+++ b/grab_disks
@@ -89,7 +89,7 @@ fi
 # to make sure the disk exist.
 #
 if [ $numb_disks -eq 0 ]; then
-	echo  "Need to have disks to do fio"
+	echo  "Need to have disks to perform desks, non provided."
 	exit 1
 fi
 echo  $disks:$numb_disks

--- a/grab_disks
+++ b/grab_disks
@@ -89,7 +89,7 @@ fi
 # to make sure the disk exist.
 #
 if [ $numb_disks -eq 0 ]; then
-	echo  "Need to have disks to perform disks, none provided."
+	echo  "Need to have disks to perform the requested test.  No disks have been provided/found."
 	exit 1
 fi
 echo  $disks:$numb_disks


### PR DESCRIPTION
An error message indicates fio test.  This is misleading as this tool can be used by many different tests.