### PR TITLE
Updates to verification code based on actual usage.

### DIFF
--- a/general_setup
+++ b/general_setup
@@ -169,6 +169,11 @@ do
 		--test_verification)
 			i=$((i + 2))
 			to_test_verify_file=$2
+			echo $to_test_verify_file |grep -q "^/" 
+			if [[ $? -ne 0 ]]; then
+				tdir=`echo $test_cmd | rev | cut -d'/' -f2- | rev`
+				to_test_verify_file=${tdir}/${to_test_verify_file}
+			fi
 			shift 2
 		;;
 		--tuned_setting)

--- a/validate_line
+++ b/validate_line
@@ -51,7 +51,7 @@ validate_line()
 		#
 		# String, needs to match.
 		#
-		grep -Fq "^${value}:" $base_results_file
+		grep -q "^${value}:" $base_results_file
 		if [ $? -ne 0 ]; then
 			error_out $field_index $field_type $line "Does not have match in the results file"
 		fi

--- a/verification
+++ b/verification
@@ -9,6 +9,7 @@ curdir=`pwd`
 home_parent=""
 run_user=""
 vdir=""
+ertc=0
 
 verification_run()
 {
@@ -39,12 +40,16 @@ verification_run()
 		base_res_file=`ls $vdir/$test_base_results/*csv`
 		if [[ $? -ne 0 ]]; then
 			echo "Error, did not find a csv file in $vdir/$test_base_results"
+			ertc=1
 			continue
 		fi
 		rdir=`diff $verify_res_after $verify_res_before | grep -v tar | grep '<' |  sed "s/< //g"`
 		res_dir=${home_parent}/${run_user}/export_results/$rdir
 		new_res_file=`find $res_dir -print | grep csv | grep results | tail -1`
 		$TOOLS_BIN/validate_line --results_file $new_res_file --fields "$fields" --base_results_file $base_res_file
+		if [[ $? -ne 0 ]]; then
+			ertc=1
+		fi
 	done < "tests_to_run"
 	rm -rf $verify_res_after $verify_res_before
 }
@@ -115,4 +120,7 @@ while [[ $# -gt 0 ]]; do
 done
 vdir=`echo $verify_file | rev | cut -d / -f 3- | rev`
 verification_run
-exit 0
+if [[ $ertc -ne 0 ]]; then
+	echo Error verification of one or more items failed.
+fi
+exit $ertc

--- a/verification
+++ b/verification
@@ -36,28 +36,11 @@ verification_run()
 		pushd ${home_parent}/${run_user}/export_results > /dev/null
 		ls -d * > $verify_res_after
 		popd >/dev/null
-		file_to_check=`diff $verify_res_after $verify_res_before | grep -v tar | grep '<' |  sed "s/< //g"`
-		#
-		# Check dir contents first
-		#
-		files_present=$verify_res_before
-		pushd ${home_parent}/${run_user}/export_results
-		ls -R ${home_parent}/${run_user}/export_results/$file_to_check/* | cut -d'/' -f 6- > $verify_res_before
-		res_dir=${home_parent}/${run_user}/export_results/$file_to_check
-		popd > /dev/null
-		pushd $vdir/$test_base_results > /dev/null
-		ls -R * | cut -d'/' -f 3- > $verify_res_after
-		tfile=`ls *csv`
-		base_res_file=$vdir/$test_base_results/tfile
-		popd > /dev/null
-		diff -q $verify_res_before $verify_res_after > /dev/null
-		if [ $? -ne 0 ]; then
-			echo Warning: There are different files/file names between the results.
-			echo Files may still be valid as things like threads etc can be different.
-			diff $verify_res_before $verify_res_after
-		fi
+		base_res_file=`ls $vdir/$test_base_results/*csv`
+		rdir=`diff $verify_res_after $verify_res_before | grep -v tar | grep '<' |  sed "s/< //g"`
+		res_dir=${home_parent}/${run_user}/export_results/$rdir
 		new_res_file=`find $res_dir -print | grep csv | grep results | tail -1`
-		$TOOLS_BIN/validate_line --results_file $new_res_file --fields "$fields" --header_lines $header_lines --base_results_file $base_res_file
+		$TOOLS_BIN/validate_line --results_file $new_res_file --fields "$fields" --base_results_file $base_res_file
 	done < "tests_to_run"
 	rm -rf $verify_res_after $verify_res_before
 }

--- a/verification
+++ b/verification
@@ -37,6 +37,10 @@ verification_run()
 		ls -d * > $verify_res_after
 		popd >/dev/null
 		base_res_file=`ls $vdir/$test_base_results/*csv`
+		if [[ $? -ne 0 ]]; then
+			echo "Error, did not find a csv file in $vdir/$test_base_results"
+			continue
+		fi
 		rdir=`diff $verify_res_after $verify_res_before | grep -v tar | grep '<' |  sed "s/< //g"`
 		res_dir=${home_parent}/${run_user}/export_results/$rdir
 		new_res_file=`find $res_dir -print | grep csv | grep results | tail -1`


### PR DESCRIPTION
# Description
The verification  code needs to figure out the proper path to the file is
There are two options
1) absolute path, if it starts with a "/" nothing is done.
2) If an absolute path is not provide, we assume a relative path based on the git repo.  We drop off the last text after the / in the path of the executable, and then append the relative path.
3) Remove check for filenames that are different, only check the csv file.

# Before/After Comparison
Before we would need to provide the absolute path at all times.  This will cause issues with running the verification tests from zathras.

After:
We now just have to point to the test results from where it is, relative to the git repo 


# Clerical Stuff
This closes #52


Relates to JIRA: RPOPC-345
