### PR TITLE
Change verification to use regular expressions.

### DIFF
--- a/general_setup
+++ b/general_setup
@@ -170,7 +170,7 @@ do
 			i=$((i + 2))
 			to_test_verify_file=$2
 			#
-			# If the path is relative, than we make it absolute by
+			# If the path is relative, then we make it absolute by
 			# using the the path of general_setup, minus the test_tools dir.
 			#
 			echo $to_test_verify_file |grep -q "^/" 

--- a/general_setup
+++ b/general_setup
@@ -169,6 +169,10 @@ do
 		--test_verification)
 			i=$((i + 2))
 			to_test_verify_file=$2
+			#
+			# If the path is relative, than we make it absolute by
+			# using the the path of general_setup, minus the test_tools dir.
+			#
 			echo $to_test_verify_file |grep -q "^/" 
 			if [[ $? -ne 0 ]]; then
 				tdir=`echo $test_cmd | rev | cut -d'/' -f2- | rev`

--- a/general_setup
+++ b/general_setup
@@ -169,6 +169,11 @@ do
 		--test_verification)
 			i=$((i + 2))
 			to_test_verify_file=$2
+			echo $to_test_verify_file |grep -q "^/" 
+			if [[ $? -ne 0 ]]; then
+				tdir=`echo $test_cmd | rev | cut -d'/' -f2- | rev`
+				to_test_verify_file=${tdir}/${to_test_verify_file}
+			fi
 			shift 2
 		;;
 		--tuned_setting)
@@ -207,7 +212,7 @@ if [[ $to_tuned_setting == "" ]]; then
 	to_tuned_setting=`${TOOLS_BIN}/get_tuned_setting`
 fi
 if [[ $to_test_verify_file != "" ]]; then
-	$TOOLS_BIN/verification --test_cmd $test_cmd --verify_file $to_test_verify_file --run_user $to_user --home_parent $to_home_root 
+	$TOOLS_BIN/verification --test_cmd $test_cmd --test_name $test_name --verify_file $to_test_verify_file --run_user $to_user --home_parent $to_home_root 
 	exit $?
 fi
 if [ $to_times_to_run -eq 0 ]; then

--- a/validate_line
+++ b/validate_line
@@ -47,10 +47,18 @@ error_out()
 
 validate_lines()
 {
+	#
+	# Perform the comparison of what we expect, to what we have.
+	#
+	# Format of passed file is "regexp" "data string"
+	#
 	while IFS= read -r test_info
 	do
 		regexp=`echo "$test_info" |  cut  -f 1`
 		string=`echo "$test_info" |  cut  -f 2`
+		#
+		# Check to see if the string matches the regular expression.
+		#
 		echo $string | grep -E -q "$regexp"
 		if [[ $? -ne 0 ]]; then
 			echo "Error: Field regex mismatch, $regexp we have $string"
@@ -126,16 +134,19 @@ field_index=1
 rm -f tmp_results compare_file
 while IFS= read -r test_info
 do
-	#
-	# Skip over meta head
-	#
 	if [ $meta_head -eq 0 ]; then
+		#
+		# Skip over meta head
+		#
 		if [[ $test_info == *"# Test general meta end"* ]]; then
 			meta_head=1
 		fi
 		continue
 	fi
 	if [[ $test_info == *"Test meta data start"* ]] then
+		#
+		# Skip over the test meta data.
+		#
 		meta_test=1
 		continue
 	fi
@@ -147,6 +158,10 @@ do
 	fi
 	echo $test_info >> tmp_results
 done < "$results_file"
+#
+# Create the compare file  by pasting the base results (reg exp) against the tmp_results
+# file which is minus all the meta documentation.
+#
 paste $base_results_file tmp_results > compare_file
 validate_lines compare_file
 rm compare_file

--- a/validate_line
+++ b/validate_line
@@ -1,5 +1,23 @@
 #!/bin/bash
+#
+# Copyright (C) 2025  David Valin dvalin@redhat.com
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
 
+exit_rtc=0
 base_results_file=""
 
 usage()
@@ -27,43 +45,18 @@ error_out()
 	exit 1
 }
 
-validate_line()
+validate_lines()
 {
-	re='^[0-9]+$'
-	line=$1
-	field_index=`echo $2 | cut -d':' -f 1`
-	field_type=`echo $2 | cut -d':' -f 2`
-
-	value=`echo $1 | cut -d':' -f $field_index | sed "s/ //g"`
-	if [[ $value == "" ]]; then
-		error_out $field_index $field_type $line "Either field is not present, or has no value."
-	fi
-	if [[ $field_type == "n" ]]; then
-		#
-		# Handle floats also.
-		#
-		check_value=`echo $value | sed "s/\./0/g"`
-		if ! [[ $check_value =~ $re ]] ; then
-			error_out $field_index $field_type $line "Non numerical field"
+	while IFS= read -r test_info
+	do
+		regexp=`echo "$test_info" |  cut  -f 1`
+		string=`echo "$test_info" |  cut  -f 2`
+		echo $string | grep -E -q "$regexp"
+		if [[ $? -ne 0 ]]; then
+			echo "Error: Field regex mismatch, $regexp we have $string"
+			exit_rtc=1
 		fi
-	fi
-	if [[ $field_type == "sm" ]]; then
-		#
-		# String, needs to match.
-		#
-		grep -Fq "^${value}:" $base_results_file
-		if [ $? -ne 0 ]; then
-			error_out $field_index $field_type $line "Does not have match in the results file"
-		fi
-	fi
-	if [[ $field_type == "s" ]]; then
-		#
-		# Just a simple string.
-		#
-		if [[ $value == "" ]]; then
-			error_out $field_index $field_type $line "Should be string value in the results file"
-		fi
-	fi
+	done < "$1"
 }
 
 ARGUMENT_LIST=(
@@ -125,10 +118,12 @@ while [[ $# -gt 0 ]]; do
 done
 
 meta_head=0
+meta_test=0
 header_line=""
 field_location=""
 separ=""
 field_index=1
+rm -f tmp_results compare_file
 while IFS= read -r test_info
 do
 	#
@@ -140,25 +135,19 @@ do
 		fi
 		continue
 	fi
-	if [[ $header_line == "" ]]; then
-		header_line=`echo $test_info | sed "s/ /_/g" | sed "s/:/ /g"`
-		for field in $header_line; do
-			for find_field in $fields; do
-				value=`echo $find_field | cut -d':' -f 1`
-				type=`echo $find_field | cut -d':' -f 2`
-				if [[ $value == $field ]]; then
-					field_location=${field_location}${separ}${field_index}:${type}
-					let "field_index=${field_index}+1"
-					separ=" "
-					break
-				fi
-			done
-		done
+	if [[ $test_info == *"Test meta data start"* ]] then
+		meta_test=1
 		continue
 	fi
-	for field in $field_location; do
-		validate_line "$test_info" $field
-	done
+	if [[ $meta_test -eq 1 ]]; then
+		if [[ $test_info == *"Test meta data end*" ]] then
+			meta_test=0
+		fi
+		continue
+	fi
+	echo $test_info >> tmp_results
 done < "$results_file"
-
-exit 0
+paste $base_results_file tmp_results > compare_file
+validate_lines compare_file
+rm compare_file
+exit $exit_rtc

--- a/verification
+++ b/verification
@@ -56,9 +56,15 @@ verification_run()
 		pushd ${home_parent}/${run_user}/export_results > /dev/null
 		ls -d * > $verify_res_after
 		popd >/dev/null
+		#
+		# Determine what directory is new.
+		#
 		base_res_file=$vdir/$test_base_results
 		rdir=`diff $verify_res_after $verify_res_before | grep -v tar | grep '<' |  sed "s/< //g"`
 		res_dir=${home_parent}/${run_user}/export_results/$rdir
+		#
+		# Locate the test csv file
+		#
 		new_res_file=`find $res_dir -print | grep results_${test_name}.csv`
 		$TOOLS_BIN/validate_line --results_file $new_res_file --fields "$fields" --base_results_file $base_res_file
 		if [[ $? -ne 0 ]]; then

--- a/verification
+++ b/verification
@@ -1,14 +1,34 @@
 #!/bin/bash
 #
+# Copyright (C) 2025  David Valin dvalin@redhat.com
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+
+#
 # Using a set of known results files, verify the test is still correct.
 #
 TOOLS_BIN=`echo $0 | rev | cut -d/ -f2- | rev`
 test_cmd=""
+test_name=""
 verify_file=""
 curdir=`pwd`
 home_parent=""
 run_user=""
 vdir=""
+exit_rtc=0
 
 verification_run()
 {
@@ -36,30 +56,20 @@ verification_run()
 		pushd ${home_parent}/${run_user}/export_results > /dev/null
 		ls -d * > $verify_res_after
 		popd >/dev/null
-		file_to_check=`diff $verify_res_after $verify_res_before | grep -v tar | grep '<' |  sed "s/< //g"`
-		#
-		# Check dir contents first
-		#
-		files_present=$verify_res_before
-		pushd ${home_parent}/${run_user}/export_results
-		ls -R ${home_parent}/${run_user}/export_results/$file_to_check/* | cut -d'/' -f 6- > $verify_res_before
-		res_dir=${home_parent}/${run_user}/export_results/$file_to_check
-		popd > /dev/null
-		pushd $vdir/$test_base_results > /dev/null
-		ls -R * | cut -d'/' -f 3- > $verify_res_after
-		tfile=`ls *csv`
-		base_res_file=$vdir/$test_base_results/tfile
-		popd > /dev/null
-		diff -q $verify_res_before $verify_res_after > /dev/null
-		if [ $? -ne 0 ]; then
-			echo Warning: There are different files/file names between the results.
-			echo Files may still be valid as things like threads etc can be different.
-			diff $verify_res_before $verify_res_after
+		base_res_file=$vdir/$test_base_results
+		rdir=`diff $verify_res_after $verify_res_before | grep -v tar | grep '<' |  sed "s/< //g"`
+		res_dir=${home_parent}/${run_user}/export_results/$rdir
+		new_res_file=`find $res_dir -print | grep results_${test_name}.csv`
+		$TOOLS_BIN/validate_line --results_file $new_res_file --fields "$fields" --base_results_file $base_res_file
+		if [[ $? -ne 0 ]]; then
+			exit_rtc=1
 		fi
-		new_res_file=`find $res_dir -print | grep csv | grep results | tail -1`
-		$TOOLS_BIN/validate_line --results_file $new_res_file --fields "$fields" --header_lines $header_lines --base_results_file $base_res_file
 	done < "tests_to_run"
-	rm -rf $verify_res_after $verify_res_before
+	if [[ $? -eq 0 ]]; then
+		rm -rf $verify_res_after $verify_res_before
+	else
+		echo $verify_res_after $verify_res_before
+	fi
 }
 
 usage()
@@ -68,6 +78,7 @@ usage()
 	echo "home_parent <dir>: Parent of the users home directory."
 	echo "run_user <user>:  Name of user running the test."
 	echo "test_cmd <command>: Test wrapper that is being executed."
+	echo "test_name <name>: Name of test being run."
 	echo "verify_file <file>: Path to the test verification file."
 	exit $2
 }
@@ -77,6 +88,7 @@ ARGUMENT_LIST=(
 	"home_parent"
 	"run_user"
 	"test_cmd"
+	"test_name"
 	"verify_file"
 )
 NO_ARGUMENTS=(
@@ -111,6 +123,10 @@ while [[ $# -gt 0 ]]; do
 			test_cmd=$2
 			shift 2
 		;;
+		--test_name)
+			test_name=$2
+			shift 2
+		;;
 		--usage)
 			usage $0 0
 		;;
@@ -128,4 +144,4 @@ while [[ $# -gt 0 ]]; do
 done
 vdir=`echo $verify_file | rev | cut -d / -f 3- | rev`
 verification_run
-exit 0
+exit $exit_rtc


### PR DESCRIPTION
# Description
Replaces the comparisons in the tests verification files to use regular expressions

# Before/After Comparison
Before change: expression would have been define as
fields: ht_config:s,sockets:n,threads:n,unit:s,MB/sec:n,cpu_affin:s

Now uses regular expressions
, and will look like
ht_config:sockets:threads:unit:MB/sec:cpu_affin
ht_yes_1_socket:[[:digit:]]{1,}:[[:digit:]]{1,}:GFlops:[[:digit:]]{1,}:[ 0-9,]{1,}$


# Clerical Stuff

This closes #54 


Relates to JIRA: RPOPC-229
