### PR TITLE
Current validate works for some but not all.  Missed a change.

### DIFF
--- a/validate_line
+++ b/validate_line
@@ -195,7 +195,6 @@ header_processed=0
 
 grep -q "Test general meta end" $results_file
 meta_head=$?
-echo meta_head $meta_head
 while IFS= read -r test_info
 do
 	if [ $meta_head -eq 0 ]; then
@@ -272,7 +271,7 @@ done < "$results_file"
 # Create the compare file  by pasting the base results (reg exp) against the tmp_results
 # file which is minus all the meta documentation.
 #
-paste $base_results_file $test_results > $compare_file
+paste $verification_base $test_results > $compare_file
 validate_lines $compare_file
 rm -f $compare_file $verification_base $verify_template $test_results
 if [[ $exit_rtc -ne 0 ]]; then


### PR DESCRIPTION
# Description
We are using the wrong file for the results being compared.  For the most part, it works fine, but there will be cases where it will fail (depends on the directives being passed, ie %_header).  While we are in the code we are removing a debug statement.

# Before/After Comparison
Before the change:  auto_hpl will get a false fail, as we are not using the file that filtered out the directives.
After the change.  If auto_hpl results matches the regexp, than we report "Ran" as expected.

# Clerical Stuff
This closes #66 

Relates to JIRA: RPOPC-496

Testing

Verified that the file file being used is the proper file, via
1) Visual inspection
2) Actual execution of test.

Also verified both cases of pass and fail.  auto_hpl test used as it was the first one to encounter the error.
