### PR TITLE
Fix issue with using wrong file for multiple lines.

### DIFF
--- a/validate_line
+++ b/validate_line
@@ -267,6 +267,9 @@ do
 	fi
 	echo $test_info >> $test_results
 done < "$results_file"
+if [[ $multiple_entries -eq 1 ]]; then
+	mv $verify_template $verification_base
+fi
 #
 # Create the compare file  by pasting the base results (reg exp) against the tmp_results
 # file which is minus all the meta documentation.


### PR DESCRIPTION
# Description
Fixes code in validate_line to use the right file when we havethe directive %_multiples.  Without this change we can get false error reporting.

# Before/After Comparison
Before: Results validation involving multiple lines may report incorrect status.
After:  Proper run status is reported for multiple line directive.
# Clerical Stuff
This closes #69 

Relates to JIRA: RPOPC-500

# Testing

Verified that when fixed, that we get the proper results when using %_multiples directive.
