### PR TITLE
Initial support of PCP metrics gathering capability

### DIFF
--- a/general_setup
+++ b/general_setup
@@ -68,6 +68,7 @@ gs_usage_info()
 	echo "  --tuned_setting: used in naming the tar file, default for RHEL is the current active tuned.  For non"
 	echo "    RHEL systems, default is none."
 	echo "  --usage: this usage message."
+	echo "  --use_pcp: Enables use of Performance Co-Pilot in wrappers, defaults to 0."
 	exit 1
 }
 
@@ -92,6 +93,7 @@ to_pstats="default"
 to_no_pkg_install=0
 
 to_tuned_setting=""
+to_use_pcp=0
 
 i=1
 j=$#
@@ -195,6 +197,10 @@ do
 		--usage)
 			gs_usage_info
 		;;
+		--use_pcp)
+ 			i=$((i + 1))
+ 			to_use_pcp=1
+ 			shift 1
 		--)
 			break; 
 		;;

--- a/pcp/PCPrecord.service
+++ b/pcp/PCPrecord.service
@@ -1,0 +1,10 @@
+[Unit]
+Description=PCP Recorder
+
+[Service]
+Type=notify
+WorkingDirectory=/usr/local/src/PCPrecord
+ExecStart=/usr/local/src/PCPrecord/PCPrecord_actions.sh
+
+[Install]
+WantedBy=multi-user.target

--- a/pcp/PCPrecord_actions.sh
+++ b/pcp/PCPrecord_actions.sh
@@ -1,0 +1,134 @@
+#!/bin/bash
+# Executed by systemd service 'PCPrecord.service'
+# See: /etc/systemd/system/PCPrecord.service
+################################################################
+
+# GLOBALS ###################
+# Include the PCP Functions file
+source $PWD/pcp_functions.inc
+
+FIFO="/tmp/pcpFIFO"                 # get from cmdline
+sample_rate=5                       # hardcode DEFAULT for now
+pmlogger_running="false"            # Initialize service as OFF
+om_workload_file="/tmp/openmetrics_workload.txt"
+om_workload_file_reset="/tmp/openmetrics_workload_reset.txt"
+
+#############################
+# Functions #################
+
+reset_om_metrics() {
+    echo "Reset OpenMetrics values"
+    cp ${om_workload_file_reset} ${om_workload_file}
+}
+
+error_exit() {
+    if [ "$?" != "0" ]; then
+        systemd-notify --status="ERROR: $1"
+        # Additional error handling logic can be added here
+        rm -f "$FIFO"
+        # Reset openmetric.workload metric values prior to leaving
+        reset_om_metrics
+## if pmlogger_running = True then attempt forcible STOP?
+        exit 1
+    fi
+}
+# END Functions #################
+
+# Main #################
+# Initialize openmetric.workload metric values
+reset_om_metrics
+
+# Verify required files and Packages are available
+#----------------------------------
+test -f "${om_workload_file}"
+error_exit "Initialization: ${om_workload_file} not found!"
+
+# Remove and recreate FIFO on every service 'start'
+rm -f "$FIFO"
+mkfifo "$FIFO"
+error_exit "Initialization: mkfifo $FIFO failed"
+
+## DEBUG - measure processing interval: $postaction-$preaction
+action='NONE'
+interval=0.0
+
+# Infinite Loop  #################
+# Read FIFO and perform requested ACTION (start, stop, ...)
+# Access each word in $action string for parsing 'actions' & 'metric'
+# NOTE: 'Start, Stop, Reset' actions have no metrics
+while : ; do
+    # Required or we get TIMEOUT on 'read action < "$FIFO" '
+    # Signal readiness for next $action. SYNC point w/client Workload
+    # Report timing interval for most recent ACTION
+    systemd-notify --ready --status="READY: last-action - $action = ${interval}ms"
+    # Read the Request/'$action' and then process it
+    read action < "$FIFO"       # Blocks until data is available
+    # Signal busy Processing this $action
+    systemd-notify --status="$action PMLOGGER Request"
+    action_arr=($action)        # Array of 'words' in Request read from FIFO
+## DEBUG - measure processing interval for ACTION: $postaction-$preaction
+    preaction=$(mark_ms)
+    case "${action_arr[0]}" in
+        Start)     # 'Start $archive_dir $test_name $conf_file' 
+            archive_dir="${action_arr[1]}"
+            archive_name="${action_arr[2]}"
+            conf_file="${action_arr[3]}"
+            # Start PMLOGGER to create ARCHIVE
+            if [ "$pmlogger_running" = "false" ]; then
+                # Signal Processing this $action
+                systemd-notify --status="DEBUG: $action PMLOGGER Request"
+                # These functions attempt to catch errors and verify success
+                pcp_verify $conf_file
+                error_exit "pcp_verify: Unable to start PMLOGGER"
+                pcp_start $conf_file $sample_rate $archive_dir $archive_name
+                error_exit "pcp_start: Unable to start PMLOGGER"
+                pmlogger_running="true"       # Record this STATE info
+            fi
+            ;;
+        Stop)      # artifacts_dir="${action_arr[1]}"
+            # Terminate PMLOGGER 
+            if [ "$pmlogger_running" = "true" ]; then
+                # Will ZATHRAS Store PCP Archive related artifacts ?
+                #  - Currently Missing from PCPSTOP logic
+                ##pcp_stop "${artifacts_dir}"
+                pcp_stop
+                error_exit "pcp_stop: Unable to stop PMLOGGER"
+                pmlogger_running="false"
+            fi
+            ;;
+        Reset)   # om_workload_file="${action_arr[1]}"
+            # RESET the Workload Metrics
+            # the only Request that doesn't require $pmlogger_running
+            reset_om_metrics
+            error_exit "reset_om_metrics: Unable to RESET Workload Metrics"
+            ;;
+        throughput|latency|numthreads|runtime)      # Workload Metrics
+            # metric="${action_arr[1]}"  om_workload_file=$2
+            if [ "$pmlogger_running" = "true" ]; then
+                # Forward workload metric to openmetrics_workload.txt
+                # Change only one metric line at a time
+                # Replaces the entire line using sed
+                # Should I only print 'action_arr[0] & action_arr[1]'
+                sed -i "s/^.*${action_arr[0]}.*$/${action}/" "$om_workload_file"
+            fi
+            ;;
+        running|iteration)                          # Workload States
+            # state="${action_arr[1]}"  om_workload_file=$2
+            if [ "$pmlogger_running" = "true" ]; then
+                sed -i "s/^.*${action_arr[0]}.*$/${action}/" "$om_workload_file"
+            fi
+            ;;
+        *)
+            systemd-notify --status="Unrecognized action - IGNORED"
+            ;;
+    esac
+## DEBUG - measure time interval for processing ACTION
+    postaction=$(mark_ms)
+    interval=$(( 10*(postaction - preaction) ))
+done
+
+# Cleanup
+echo "Cleaning up"
+
+# Reset openmetric.workload metric values prior to leaving
+reset_om_metrics

--- a/pcp/default.cfg
+++ b/pcp/default.cfg
@@ -1,0 +1,76 @@
+#pmlogconf 2.0
+#
+## Workload Metrics - hardcoded sampling rate
+log advisory on 1 second {
+        openmetrics.workload
+        openmetrics.control.fetch_time
+}
+
+## Intel RAPL & RFchassis metrics
+log advisory on default {
+#	denki.rapl
+        openmetrics.RFchassis
+}
+
+## platform, filesystem and hardware configuration
+log advisory on once {
+        hinv
+        kernel.uname
+        filesys.mountdir
+        filesys.uuid
+        filesys.type
+        filesys.blocksize
+        filesys.capacity
+}
+
+#+ tools/htop:y:default:
+## metrics used by the htop command
+log advisory on default {
+#        disk.all.read_bytes
+#        disk.all.write_bytes
+#        disk.all.avactive
+#        hinv.cpu.clock
+        kernel.all.load
+        kernel.all.uptime
+        kernel.all.cpu.user
+        kernel.all.cpu.nice
+        kernel.all.cpu.sys
+        kernel.all.cpu.idle
+        kernel.all.cpu.wait.total
+        kernel.all.cpu.intr
+        kernel.all.cpu.irq.soft
+        kernel.all.cpu.steal
+        kernel.all.cpu.guest
+        kernel.all.cpu.guest_nice
+#        kernel.all.pressure.cpu.some.avg
+#        kernel.all.pressure.io.some.avg
+#        kernel.all.pressure.io.full.avg
+#        kernel.all.pressure.memory.some.avg
+#        kernel.all.pressure.memory.full.avg
+#        kernel.percpu.cpu.user
+#        kernel.percpu.cpu.nice
+#        kernel.percpu.cpu.sys
+#        kernel.percpu.cpu.idle
+#        kernel.percpu.cpu.wait.total
+#        kernel.percpu.cpu.intr
+#        kernel.percpu.cpu.irq.soft
+#        kernel.percpu.cpu.steal
+#        kernel.percpu.cpu.guest
+#        kernel.percpu.cpu.guest_nice
+        mem.util.available
+        mem.util.free
+        mem.util.bufmem
+        mem.util.cached
+        mem.util.shmem
+        mem.util.slabReclaimable
+        mem.util.swapCached
+        mem.util.swapTotal
+        mem.util.swapFree
+        network.all.in.bytes
+        network.all.out.bytes
+        network.all.in.packets
+        network.all.out.packets
+#        zram.capacity
+#        zram.mm_stat.data_size.original
+#        zram.mm_stat.data_size.compressed
+}

--- a/pcp/openmetrics_default_reset.txt
+++ b/pcp/openmetrics_default_reset.txt
@@ -1,0 +1,6 @@
+iteration 0
+running 0
+numthreads 0
+runtime NaN
+throughput NaN
+latency NaN

--- a/pcp/pcp_commands.inc
+++ b/pcp/pcp_commands.inc
@@ -1,0 +1,131 @@
+FIFO="/tmp/pcpFIFO"
+timeout_long=10             # wait-time for Start and Stop actions
+timeout_short=2             # wait-time for other actions
+
+fail_exit() {
+    if [ "$?" != "0" ]; then
+        echo "ERROR: $1"
+        # Additional error handling logic can be added here
+        exit 1
+    fi
+}
+
+# Wait for the PCPrecord.SVC to report Status='READY'
+# This appears to be CPU time heavy
+# Timing can be quite finicky
+check_svc() {
+    wait_to=$1
+    # Wait for the PCPrecord.SVC to report Status='READY'
+    # This appears to be CPU time heavy
+    timeout "$wait_to" bash -c \
+      "until systemctl status PCPrecord.service | grep -q "READY:" \
+      ; do sleep 0.1; done"
+    # Trap timeout condition
+    if [ $? -eq 124 ]; then
+        echo "Timed out waiting $wait_to sec for systemd status=READY: \
+          Request=$request_str"
+        exit 2
+    fi
+}
+
+#Sets up and starts the PCP service
+setup_pcp() {
+	working_dir="/usr/local/src/PCPrecord"
+
+	mkdir -p "${working_dir}"
+	chmod 755 ${TOOLS_BIN}/pcp/*.sh
+	cp ${TOOLS_BIN}/pcp/PCPrecord.service /etc/systemd/system/.
+	cp ${TOOLS_BIN}/pcp/PCPrecord_actions.sh "${working_dir}/."
+	cp ${TOOLS_BIN}/pcp/pcp_functions.inc "${working_dir}/."
+	cp ${TOOLS_BIN}/pcp/workload.url /var/lib/pcp/pmdas/openmetrics/config.d/
+	#If there's a workload specific OM file use it. Otherwise use a generic one
+	if [[ -f ${run_dir}/openmetrics_${test_name}_reset.txt ]]; then
+		cp ${run_dir}/openmetrics_${test_name}_reset.txt /tmp/openmetrics_workload_reset.txt
+	else
+		cp ${TOOLS_BIN}/pcp/openmetrics_default_reset.txt /tmp/openmetrics_workload_reset.txt
+	fi
+	# Stop and then Restart the service
+	systemctl stop PCPrecord.service
+	systemctl stop pmcd
+	sleep 1
+	systemctl daemon-reload
+	sleep 1
+	# WHY is this issuing warning to run 'systemctl daemon-reload'?
+	systemctl start PCPrecord.service
+	systemctl start pmcd
+	sleep 1
+}
+
+#Starts PCP 
+#Sends "Start" command to PCPrecord_actions
+#Takes three args:
+#$1: Directory for PCP data, should be with the workload's own data
+#$2: Test name
+#$3: PMLogger config file to use
+start_pcp() {
+	printf "Reset\n" > $FIFO
+	echo "PCP metrics reset"
+	sleep 2
+	printf "Start ${1} ${2} ${3}\n" > $FIFO
+	echo "PCP Start Complete"
+}
+
+#Stops PCP
+#Sends "Stop" command to PCPrecord_actions
+stop_pcp() {
+	printf "Stop\n" > $FIFO
+	sleep 2
+}
+
+#Sends value to OpenMetrics file to be added to PCP archive
+#$1: metric
+#$2: value
+result2pcp() {
+	echo "Logging results ${1} ${2}"
+	#Do we know about the metric?
+	check_svc $timeout_short
+	grep -w ${1} /tmp/openmetrics_workload.txt
+	if [[ $? -eq 0 ]]; then
+		#Just log it
+		sed -i "s/^.*${1}.*$/${1} ${2}/" /tmp/openmetrics_workload.txt
+	else
+		#I don't see it. Typo? Experiment? Flag it and add it to the file
+		echo "Unexpected metric logged. Check for a typo."
+		echo "${1} ${2}" >> /tmp/openmetrics_workload.txt
+	fi
+	check_svc $timeout_short
+	sleep 2
+}
+
+#Shut the services down
+shutdown_pcp() {
+	systemctl stop PCPrecord.service
+	systemctl stop pmcd
+}
+
+#Reset the openmetrics file
+reset_pcp_om() {
+	check_svc $timeout_short
+        printf "Reset\n" > $FIFO
+        echo "PCP metrics reset"
+	check_svc $timeout_short
+	sleep 2
+}
+
+#Start a data subset if we're doing one big archive for the entire run
+#Resets OpenMetrics and sets the "running" flag so graphs will show the times we care about
+start_pcp_subset() {
+	reset_pcp_om
+	echo "Starting PCP subset"
+	printf "running 1" > $FIFO
+	check_svc $timeout_short
+	sleep 2
+}
+
+#Stop a data subset if we're doing one big archive for the entire run
+stop_pcp_subset() {
+	echo "Stopping PCP subset"
+	printf "running 0" > $FIFO
+	check_svc $timeout_short
+	sleep 2
+}

--- a/pcp/pcp_functions.inc
+++ b/pcp/pcp_functions.inc
@@ -1,0 +1,114 @@
+#!/bin/bash
+# Collection of utility Functions for working with Perf Co-Pilot
+# - pcp_verify($cfg_file)
+# - pcp_start($cfg_file, $sample_rate, $archive_dir, $archive_name)
+# - pcp_stop()
+#
+# NOTE: use of these Functions require that PCP is already installed on the system 
+##################################################################################
+
+# Global VARs
+primary_pmlogger="false"          # used to manage stop/restart
+pmlogger_killed="success"         # flags if private pmlogger was killed
+#---------------------------------------------------------------
+
+pcp_verify()
+{
+    local cfg_file="$1"          # PMLOGGER Configuration File
+# Verify user provided pmlogger.conf file exists. If not abort.
+    if [ ! -f "$cfg_file" ]; then
+        echo "File $cfg_file not found!"; echo
+        exit 20
+    fi
+
+# TBD: use 'pmlogger -c $PWD/$cfg_file -C' to Verify syntax
+
+# Verify PMCD is running (pcp-zeroconf is installed)
+    systemctl is-active --quiet pmcd
+    if [ $? != 0 ]; then
+        echo "PCP pmcd is not running. Is PCP installed?"
+        echo "Suggested syntax: sudo dnf install pcp-zeroconf"; echo
+        exit 21
+    fi
+
+# Manage primary pmlogger. STOP if it is running.
+# Check if primary pmlogger is running
+    systemctl is-active --quiet pmlogger
+    if [ $? == 0 ]; then
+        echo "Primary PCP pmlogger is running. Being stopped to run script"
+        systemctl stop pmlogger
+        # Flag indicates primary pmlogger should be restarted by 'pcp_stop'
+        primary_pmlogger="true"
+    fi
+}
+
+pcp_start()
+{
+    echo "PCP Starting private pmlogger"
+
+    local cfg_file="$1"
+    local sample_rate="$2"
+    local archive_dir="$3"
+    local archive_basename="$4"
+    local archive_loc="${archive_dir}/${archive_basename}"
+    local pmlogger_log="${archive_loc}.log"
+
+    mkdir -p "${archive_dir}"
+
+# Run PCP pmlogger
+# JTH - VERIFY success, ensure pmlogger starts
+    pmlogger -c "${cfg_file}" -t "$sample_rate" -l "${pmlogger_log}"\
+      "${archive_loc}" &
+
+# First check that the pmlogger process is running
+    timeout 5 bash -c \
+      "until pgrep pmlogger>/dev/null; do sleep 0.5; done"
+    # Trap timeout condition
+    if [ $? -eq 124 ]; then
+        echo "Timed out waiting for PMLOGGER to Start1"
+        exit 30
+    fi
+# Now check that PMLOGGER has started logging
+#    timeout 5 bash -c \
+#      "until grep -q "Starting logger " ${pmlogger_log}; do sleep 0.5; done"
+#    # Trap timeout condition
+#    if [ $? -eq 124 ]; then
+#        echo "Timed out waiting for PMLOGGER to Start2"
+#        exit 31
+#    fi
+}
+
+pcp_stop()
+{
+    echo "PCP Stop. Stopping private pmlogger, creating archive"
+
+# Stop PCP logger and pause for pmlogger to write archive
+    pkill -USR1 pmlogger
+# Now check that PMLOGGER has stopped logging
+    timeout 5 bash -c \
+      "until ! pgrep pmlogger>/dev/null; do sleep 0.5; done"
+    # Trap timeout condition
+    if [ $? -eq 124 ]; then
+        echo "Timed out waiting for PMLOGGER to Stop"
+        pmlogger_killed="failed"        # Not used -yet
+        exit 40
+    fi
+    pmlogger_killed="success"
+
+# Restore primary pmlogger, if it was previously running
+    if [ "$primary_pmlogger" == "true" ]; then
+        if [ "$pmlogger_killed" == "success" ]; then
+#DEBUG      echo "Primary PCP pmlogger being restored to original run state"
+            systemctl start pmlogger
+#DEBUG  else
+#DEBUG      echo "Primary PCP pmlogger NOT restored to original run state"
+        fi
+    fi
+}
+
+mark_ms() {
+    read up rest </proc/uptime; marker="${up%.*}${up#*.}"
+    echo "$marker"                 # return value
+}
+
+#-------------------------------------------------------

--- a/pcp/update_svc.sh
+++ b/pcp/update_svc.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+# Updates PCPrecord.service related files and restarts the service
+# To monitor the service
+#   $ watch -n 1 'systemctl status PCPrecord.service'
+###################################################################
+working_dir="/usr/local/src/PCPrecord"
+
+mkdir -p "${working_dir}"
+chmod 755 *.sh
+cp PCPrecord.service /etc/systemd/system/.
+cp PCPrecord_actions.sh "${working_dir}/."
+cp pcp_functions.inc "${working_dir}/."
+cp sbcpu.cfg "${working_dir}/."
+
+# Stop and then Restart the service
+systemctl stop PCPrecord.service
+sleep 1
+systemctl daemon-reload
+sleep 1
+# WHY is this issuing warning to run 'systemctl daemon-reload'?
+systemctl start PCPrecord.service
+sleep 1
+

--- a/pcp/workload.url
+++ b/pcp/workload.url
@@ -1,0 +1,1 @@
+file:///tmp/openmetrics_workload.txt


### PR DESCRIPTION
# Description
This add initial PCP support to the common toolset for the "Zathras family" of workload wrappers as part of the migration from pbench
- Adds "--use_pcp" option in general_setup
- Adds PCP infrastrucure including systemd service, default configs for pmlogger and openmetrics, commands and functions for use by wrappers, and sundries

# Before/After Comparison
Before: no Zathras-wide support for PCP
After: We have initial support for the use of PCP among the "Zathras family of wrapper"

# Clerical Stuff
This closes #71 
Relates to JIRA: RPOPC-517
