### PR TITLE
Check tuned to make sure did not change, also is set when told to set.

### DIFF
--- a/general_setup
+++ b/general_setup
@@ -185,7 +185,7 @@ do
 			if [[ $value != *"none"* ]]; then
 				to_tuned_setting="${value}"
 				if [ -f /usr/sbin/tuned-adm ]; then
-					tuned-adm active ${value}
+					tuned-adm profile ${value}
 					if [[ $? -ne 0 ]]; then
 						echo Warning:  Unable to set tuned profile $value.
 					fi

--- a/general_setup
+++ b/general_setup
@@ -215,6 +215,19 @@ fi
 if [[ $to_tuned_setting == "" ]]; then
 	to_tuned_setting=`${TOOLS_BIN}/get_tuned_setting`
 fi
+
+#
+#  Get the actual setting of the tuned for future comparison,
+#  Do not depend on $to_tuned_setting. It might not have set 
+#  properly to start with.
+#
+which tuned-adm >> /dev/null 2>&1
+if [[ $? -ne 0 ]]; then
+	echo tuned-adm not available > ~/tuned_before
+else
+	tuned-adm list | grep active | cut -d:  -f 2 | sed "s/^ //g" > ~/tuned_before
+fi
+
 if [[ $to_test_verify_file != "" ]]; then
 	$TOOLS_BIN/verification --test_cmd $test_cmd --test_name $test_name --verify_file $to_test_verify_file --run_user $to_user --home_parent $to_home_root 
 	exit $?

--- a/general_setup
+++ b/general_setup
@@ -186,6 +186,9 @@ do
 				to_tuned_setting="${value}"
 				if [ -f /usr/sbin/tuned-adm ]; then
 					tuned-adm active ${value}
+					if [[ $? -ne 0 ]]; then
+						echo Warning:  Unable to set tuned profile $value.
+					fi
 				else
 					echo Warning: asking for tuned setting $value, but tuned-adm is not installed.
 				fi

--- a/general_setup
+++ b/general_setup
@@ -228,7 +228,7 @@ which tuned-adm >> /dev/null 2>&1
 if [[ $? -ne 0 ]]; then
 	echo tuned-adm not available > ~/tuned_before
 else
-	tuned-adm list | grep active | cut -d:  -f 2 | sed "s/^ //g" > ~/tuned_before
+	tuned-adm active | cut -d:  -f 2 | sed "s/ //g" > ~/tuned_before
 fi
 
 if [[ $to_test_verify_file != "" ]]; then

--- a/save_results
+++ b/save_results
@@ -165,7 +165,6 @@ if [[ ! -d $export_results ]]; then
 	mkdir $export_results
 fi
 
-
 time_stamp=`date "+%Y.%m.%d-%H.%M.%S"`
 results_dir=${test_name}_${time_stamp}
 RESULTS_PATH=${export_results}/${results_dir}

--- a/save_results
+++ b/save_results
@@ -165,12 +165,33 @@ if [[ ! -d $export_results ]]; then
 	mkdir $export_results
 fi
 
+
 time_stamp=`date "+%Y.%m.%d-%H.%M.%S"`
 results_dir=${test_name}_${time_stamp}
 RESULTS_PATH=${export_results}/${results_dir}
 mkdir -p ${RESULTS_PATH}
 
 copy_file $results $RESULTS_PATH
+
+which tuned-adm >> /dev/null 2>&1
+if [[ $? -ne 0 ]]; then
+        echo tuned-adm not available > ~/tuned_after
+else
+        tuned-adm list | grep active | cut -d:  -f 2 | sed "s/^  //g" > ~/tuned_after
+fi
+diff ~/tuned_before ~/tuned_after > $RESULTS_PATH/tuned_setting
+
+if [[ $? -ne -0 ]]; then
+	echo Tuned settings have changed!!!!
+	echo Start of run
+	cat ~/tuned_before
+	echo  End of run
+	cat ~/tuned_after
+	echo "Tuned settings have changed!!!!" >> $RESULTS_PATH/tuned_setting
+else
+	echo "Tuned stayed the same." >> $RESULTS_PATH/tuned_setting
+fi
+
 
 if [[ $other_files != "" ]]; then
 	file_list=`echo $other_files | sed "s/,/ /g"`

--- a/save_results
+++ b/save_results
@@ -181,12 +181,12 @@ fi
 diff ~/tuned_before ~/tuned_after > $RESULTS_PATH/tuned_setting
 
 if [[ $? -ne -0 ]]; then
-	echo "Tuned settings have changed!!!!"
+	echo 'Tuned settings have changed!!!!'
 	echo Start of run
 	cat ~/tuned_before
 	echo  End of run
 	cat ~/tuned_after
-	echo "Tuned settings have changed!!!!" >> $RESULTS_PATH/tuned_setting
+	echo 'Tuned settings have changed!!!!' >> $RESULTS_PATH/tuned_setting
 else
 	echo "Tuned stayed the same." >> $RESULTS_PATH/tuned_setting
 fi

--- a/save_results
+++ b/save_results
@@ -177,12 +177,12 @@ which tuned-adm >> /dev/null 2>&1
 if [[ $? -ne 0 ]]; then
         echo tuned-adm not available > ~/tuned_after
 else
-        tuned-adm list | grep active | cut -d:  -f 2 | sed "s/^  //g" > ~/tuned_after
+        tuned-adm active | cut -d:  -f 2 | sed "s/ //g" > ~/tuned_after
 fi
 diff ~/tuned_before ~/tuned_after > $RESULTS_PATH/tuned_setting
 
 if [[ $? -ne -0 ]]; then
-	echo Tuned settings have changed!!!!
+	echo "Tuned settings have changed!!!!"
 	echo Start of run
 	cat ~/tuned_before
 	echo  End of run


### PR DESCRIPTION
# Description
1) Checks to make sure the tuned-adm setting of the profile succeeded.  If not, a warning message is given.
2) Checks tuned at the start of the test and at the end of the test that it has not changed.  Note this is done generically in general_setup/save_results.  So each time a tuned is changed, we need to be calling general_setup.

# Before/After Comparison
Before: Setting of tuned would fail silently.  If tuned changed during the operation of the test, nothing is reported.
After: If we fail to set the tuned we will give a warning message.  If the tuned changes during the test, a warning is given.   A new file in the results area is created, tuned_setting, that contains the tuned status at the end of the test.

# Clerical Stuff
This closes #51 
to close the issue out automatically.

Relates to JIRA: RPOPC-334

# Testing
1) Verified if nothing changed, we are told so.
2) Induced a tuned change during the middle of the test, reported back that the tuned has changed.
3) Verified that if  tuned could not set the profile, a warning is given.
