### PR TITLE
Missed a double semi adding use_pcp option

### DIFF
--- a/general_setup
+++ b/general_setup
@@ -201,6 +201,7 @@ do
  			i=$((i + 1))
  			to_use_pcp=1
  			shift 1
+	    ;;
 		--)
 			break; 
 		;;


### PR DESCRIPTION
# Description
Fixes a missing double semicolon when --use_pcp was added

# Before/After Comparison
Before: case statement is busted
After: it's fixed

# Clerical Stuff
Relates to #78 

This closes RPOPC-565
