### PR TITLE
echo of string being passed into grep -e must be quoted.

### DIFF
--- a/validate_line
+++ b/validate_line
@@ -70,7 +70,7 @@ validate_lines()
 		#
 		# Check to see if the string matches the regular expression.
 		#
-		echo $string | grep -E -q "$regexp"
+		echo "$string" | grep -E -q "$regexp"
 		if [[ $? -ne 0 ]]; then
 			echo "Error: Field regex mismatch, $regexp we have $string"
 			exit_rtc=1


### PR DESCRIPTION
# Description
Quotes the string being passed into grep -E

# Before/After Comparison
Before: A string that should fail the regexp may pass.
After: A string that should fail the regexp will fail.

# Clerical Stuff
This fixes issue #80 


Relates to JIRA: RPOPC-566
