### PR TITLE
Add SLES as a valid OS for detect_os

### DIFF
--- a/configs/detect_os.yml
+++ b/configs/detect_os.yml
@@ -20,5 +20,3 @@
 
 - name: SLES
   identifier: sles
-  #uname_pattern:
-  uname_version_pattern: "[0-0]*"

--- a/configs/detect_os.yml
+++ b/configs/detect_os.yml
@@ -17,3 +17,8 @@
   identifier: fedora
   uname_pattern: \.fc[0-9]+\.
   uname_version_pattern: "[0-9]+"
+
+- name: SLES
+  identifier: sles
+  #uname_pattern:
+  uname_version_pattern: "[0-0]*"

--- a/detect_os
+++ b/detect_os
@@ -63,7 +63,7 @@ install_deps()
             elif command -v apt > /dev/null 2>&1; then
                 apt install -y wget
             else
-		zypper install -y wget
+                zypper install -y wget
             fi
         fi
 
@@ -117,12 +117,12 @@ parse_uname()
         local identifier=`yq -r ".[$i].identifier" $config`
         local ver_pattern=`yq -r ".[$i].uname_version_pattern" $config`
 
-        if [ -z ver_pattern ]; then
+        if [ -z "$ver_pattern" ]; then
             echo $identifier has no uname_version_pattern, skipping
             continue
         fi
 
-	if [ -z pattern ]; then
+	if [ -z "$pattern" ]; then
 	    echo $identifier has no uname_pattern, skipping
 	    continue
 	fi

--- a/detect_os
+++ b/detect_os
@@ -62,8 +62,11 @@ install_deps()
                 yum install -y wget
             elif command -v apt > /dev/null 2>&1; then
                 apt install -y wget
-            else
+	    elif command -v zypper > /dev/null 2>&1; then
                 zypper install -y wget
+	    else
+		echo "Missing wget, and do not know what package manager is being used, exiting out"
+		exit 1
             fi
         fi
 

--- a/detect_os
+++ b/detect_os
@@ -60,8 +60,10 @@ install_deps()
         if ! command -v wget > /dev/null 2>&1; then
             if command -v yum > /dev/null 2>&1; then
                 yum install -y wget
-            else
+            elif command -v apt > /dev/null 2>&1; then
                 apt install -y wget
+            else
+		zypper install -y wget
             fi
         fi
 
@@ -119,6 +121,11 @@ parse_uname()
             echo $identifier has no uname_version_pattern, skipping
             continue
         fi
+
+	if [ -z pattern ]; then
+	    echo $identifier has no uname_pattern, skipping
+	    continue
+	fi
         
         local os_match=`echo $kinfo | grep -Eo $pattern`
         

--- a/detect_os
+++ b/detect_os
@@ -122,10 +122,10 @@ parse_uname()
             continue
         fi
 
-	if [ -z "$pattern" ]; then
-	    echo $identifier has no uname_pattern, skipping
-	    continue
-	fi
+        if [ -z "$pattern" ]; then
+            echo $identifier has no uname_pattern, skipping
+            continue
+        fi
         
         local os_match=`echo $kinfo | grep -Eo $pattern`
         

--- a/detect_os
+++ b/detect_os
@@ -65,8 +65,8 @@ install_deps()
 	    elif command -v zypper > /dev/null 2>&1; then
                 zypper install -y wget
 	    else
-		echo "Missing wget, and do not know what package manager is being used, exiting out"
-		exit 1
+                echo "Missing wget, and do not know what package manager is being used, exiting out"
+                exit 1
             fi
         fi
 


### PR DESCRIPTION
# Description
Add SLES as a valid target for detect_os

# Before/After Comparison
Before: detect_os will error out on SLES systems that 'sles' is not a known OS and tests will abort
After: SLES is properly identified and tests run to completion

# Clerical Stuff
This closes #84

Relates to JIRA: RPOPC-569