### PR TITLE
Remove unneeded package from dnf

### DIFF
--- a/pcp/pcp_commands.inc
+++ b/pcp/pcp_commands.inc
@@ -55,7 +55,7 @@ setup_pcp()
 	# If pmlogger isn't present, install the PCP bits
 	pcp_present=$(which pmlogger)
 	if [[ $? -ne 0 ]]; then 
-		dnf install -y dnf install -y --setopt=tsflags=nodocs \
+		dnf install -y --setopt=tsflags=nodocs \
   		pcp-zeroconf pcp-pmda-openmetrics pcp-pmda-denki
 	fi
 

--- a/pcp/pcp_commands.inc
+++ b/pcp/pcp_commands.inc
@@ -56,7 +56,7 @@ setup_pcp()
 	pcp_present=$(which pmlogger)
 	if [[ $? -ne 0 ]]; then 
 		dnf install -y dnf install -y --setopt=tsflags=nodocs \
-  		pcp-zeroconf pcp-pmda-openmetrics pcp-pmda-denki sysbench
+  		pcp-zeroconf pcp-pmda-openmetrics pcp-pmda-denki
 	fi
 
 	working_dir="/usr/local/src/PCPrecord"

--- a/pcp/pcp_commands.inc
+++ b/pcp/pcp_commands.inc
@@ -55,8 +55,7 @@ setup_pcp()
 	# If pmlogger isn't present, install the PCP bits
 	pcp_present=$(which pmlogger)
 	if [[ $? -ne 0 ]]; then 
-		dnf install -y --setopt=tsflags=nodocs \
-  		pcp-zeroconf pcp-pmda-openmetrics pcp-pmda-denki
+		package_tool --packages pcp-zeroconf,pcp-pmda-openmetrics,pcp-pmda-denki
 	fi
 
 	working_dir="/usr/local/src/PCPrecord"


### PR DESCRIPTION
# Description
This removes an unneeded package from a dnf command in setup_pcp, which lives in EPEL and will cause the dnf install to fail

# Before/After Comparison
Before: The unneeded, by-default-unobtainable package will break the dnf install
After: dnf doesn't look for a package it can't install and which we don't need

# Clerical Stuff
This closes #89 
Relates to JIRA: RPOPC-608
