### PR TITLE
commenting out RFchassis section to avoid warnings on non-drac/bmc/etc

### DIFF
--- a/pcp/default.cfg
+++ b/pcp/default.cfg
@@ -7,10 +7,10 @@ log advisory on 1 second {
 }
 
 ## Intel RAPL & RFchassis metrics
-log advisory on default {
+#log advisory on default {
 #	denki.rapl
-        openmetrics.RFchassis
-}
+#        openmetrics.RFchassis
+#}
 
 ## platform, filesystem and hardware configuration
 log advisory on once {


### PR DESCRIPTION
# Description
Comments out RFchassis section in default.cfg for PCP logging, to clear warnings on non-drac/bmc/etc systems

# Before/After Comparison
Before: warnings such as the one below are generated on non-drac/bmc/etc systems
Warning [/home/ec2-user/test_tools/pcp/default.cfg, line 13]
Problem with lookup for metric "openmetrics.RFchassis" ... logging not activated
Reason: Unknown metric name
After: openmetrics.RFchassis isn't on the "try to collect" list

# Clerical Stuff
This closes #91 
Relates to JIRA: RPOPC-614
