### PR TITLE
Add Pip packages to `package_tool`

### DIFF
--- a/deps/python_pip.json
+++ b/deps/python_pip.json
@@ -1,0 +1,16 @@
+{
+    "dependencies": {
+        "rhel": [
+            "python3-pip"
+        ],
+        "ubuntu": [
+            "python3-pip"
+        ],
+        "suse": [
+            "python3-pip"
+        ],
+        "fedora": [
+            "python3-pip"
+        ]
+    }
+}

--- a/package_tool
+++ b/package_tool
@@ -24,6 +24,45 @@ packages=""
 remove_packages=""
 wrapper_config=""
 
+base_dir=$(dirname $(realpath $0))
+running_os=$($base_dir/detect_os)
+
+# Fetches dependencies from a wrapper JSON file
+# Args:
+# - Wrapper file path
+# - os name (will lookup .dependencies.<os> within the JSON file)
+#
+# Returns:
+# CSV list of packages from the relevant section of the JSON file
+parse_json()
+{
+	json_file=$1
+	platform=$2
+
+	jq -r ".dependencies.$platform | @csv"  $json_file | tr -d '"'
+}
+
+# Append packages to a CSV list variable
+# Args:
+# - Existing CSV package list
+# - CSV list of packages to add
+#
+# Returns:
+# Full list of packages via `echo`
+append_packages()
+{
+	existing_pkgs=$1
+	pkgs=$2
+
+	if [[ -z "$existing_pkgs" ]]; then
+		echo $pkgs
+	elif [[ -z "$pkgs" ]]; then
+		echo $existing_pkgs
+	else
+		echo "$pkgs,$existing_pkgs"
+	fi
+}
+
 ARGUMENT_LIST=(
 	"is_installed"
 	"no_packages"
@@ -62,11 +101,7 @@ while [[ $# -gt 0 ]]; do
 			shift 2
 		;;
 		--packages)
-			if [[ -z "$packages" ]]; then
-				packages=$2
-			else
-				packages="$packages,$2"
-			fi
+			packages=$(append_packages $packages $2)
 			shift 2
 		;;
 		--remove_packages)
@@ -98,8 +133,6 @@ while [[ $# -gt 0 ]]; do
 done
 
 install_cmd=""
-base_dir=$(dirname $(realpath $0))
-running_os=$($base_dir/detect_os)
 case "$running_os" in
 	"ubuntu")
 		install_cmd="/bin/apt"
@@ -138,12 +171,9 @@ if [ $update -ne 0 ]; then
 fi
 
 if [[ -n "$wrapper_config" ]]; then
-	wrapper_pkgs=$(jq -r ".dependencies.$running_os | @csv" $wrapper_config | tr -d '"')
-	if [[ -z "$packages" ]]; then
-		packages=$wrapper_pkgs
-	else
-		packages="$packages,$wrapper_pkgs"
-	fi
+	wrapper_pkgs=$(parse_json $wrapper_config $running_os)
+	
+	packages=$(append_packages $packages $wrapper_pkgs)
 fi
 
 if [[ $packages != "" ]]; then

--- a/package_tool
+++ b/package_tool
@@ -34,7 +34,7 @@ ARGUMENT_LIST=(
 
 NO_ARGUMENTS=(
 	"update"
-        "usage"
+	"usage"
 )
 
 
@@ -53,31 +53,31 @@ while [[ $# -gt 0 ]]; do
         case "$1" in
 		--is_installed)
 			is_installed=$2
-                        shift 2
+			shift 2
 		;;
 		--no_packages)
 			if [[ $2 == "1" ]]; then
 				exit 0
 			fi
-                        shift 2
+			shift 2
 		;;
-                --packages)
-						if [[ -z "$packages" ]]; then
-							packages=$2
-						else
-							packages="$packages,$2"
-						fi
-                        shift 2
-                ;;
-                --remove_packages)
-                        remove_packages=$2
-                        shift 2
-                ;;
-                --update)
+		--packages)
+			if [[ -z "$packages" ]]; then
+				packages=$2
+			else
+				packages="$packages,$2"
+			fi
+			shift 2
+		;;
+		--remove_packages)
+			remove_packages=$2
+			shift 2
+		;;
+		--update)
 			update=1
-                        shift 1
-                ;;
-                --usage)
+			shift 1
+		;;
+		--usage)
 			usage $0
 		;;
 		--wrapper_config)

--- a/package_tool
+++ b/package_tool
@@ -23,6 +23,7 @@ is_installed=""
 packages=""
 remove_packages=""
 wrapper_config=""
+pip_packages=""
 
 base_dir=$(dirname $(realpath $0))
 running_os=$($base_dir/detect_os)
@@ -63,12 +64,26 @@ append_packages()
 	fi
 }
 
+# Installs pip packages
+# No args, no return
+# Will exit_out if unable to install a pip package
+install_pip_pkgs() {
+	install_cmd="python3 -m pip install --quiet"
+	for pip_pkg in $(echo $pip_packages | sed -e 's/,/ /g'); do
+		$install_cmd $pip_pkg
+		if [[ $? -ne 0 ]]; then
+			exit_out "$install_cmd failed to install $pip_pkg" 1
+		fi
+	done
+}
+
 ARGUMENT_LIST=(
 	"is_installed"
 	"no_packages"
 	"packages"
 	"remove_packages"
 	"wrapper_config"
+	"pip_packages"
 )
 
 NO_ARGUMENTS=(
@@ -102,6 +117,10 @@ while [[ $# -gt 0 ]]; do
 		;;
 		--packages)
 			packages=$(append_packages $packages $2)
+			shift 2
+		;;
+		--pip_packages)
+			pip_packages=$(append_packages $pip_packages $2)
 			shift 2
 		;;
 		--remove_packages)
@@ -172,8 +191,16 @@ fi
 
 if [[ -n "$wrapper_config" ]]; then
 	wrapper_pkgs=$(parse_json $wrapper_config $running_os)
+	wrapper_pip=$(parse_json $wrapper_config pip)
 	
 	packages=$(append_packages $packages $wrapper_pkgs)
+	pip_packages=$(append_packages $pip_packages $wrapper_pip)
+fi
+
+# Ensure pip is available for the python3 interpreter.
+if [[ -n "$pip_packages" ]]; then
+	pip_os_pkg=$(parse_json $base_dir/deps/python_pip.json $running_os)
+	packages=$(append_packages $packages $pip_os_pkg)
 fi
 
 if [[ $packages != "" ]]; then
@@ -184,5 +211,9 @@ if [[ $packages != "" ]]; then
 			 exit_out "$install_cmd install of $package failed" 1
 		fi
 	done
+fi
+
+if [[ -n "$pip_packages" ]]; then
+	install_pip_pkgs
 fi
 exit 0


### PR DESCRIPTION
# Description
Adds pip packages to be installed by `package_tool`, through `--pip_packages` and `.dependencies.pip` in a JSON file

# Before/After Comparison
## Before
Pip packages needed to be installed by the wrapper

## After
Default python interpreter pip packages can be installed by `package_tool`

# Clerical Stuff
Mention the issue this PR works toward resolving.  If the 
PR completely solves the issue, use "This closes #x"
to close the issue out automatically.

Mention the JIRA ticket of the issue, this helps keep 
everything together so we can find this PR easily.

Relates to JIRA: RPOPC-<TICKET_NUMBER>
