### PR TITLE
Add error message when OS/platform is not in wrapper config

### DIFF
--- a/package_tool
+++ b/package_tool
@@ -43,7 +43,12 @@ parse_json()
 	json_file=$1
 	platform=$2
 
-	jq -r ".dependencies.$platform | @csv"  $json_file | tr -d '"'
+	packages=$(jq -r ".dependencies.$platform | @csv" $json_file 2> /dev/null)
+
+	if [[ $? -ne 0 ]]; then
+		echo "WARN: Could not find dependency information for $platform in $json_file, this could be intended behavior" > /dev/stderr
+	fi
+	echo $packages | tr -d '"'
 }
 
 # Append packages to a CSV list variable


### PR DESCRIPTION
# Description
Moves `jq` parsing and the `tr` cleanup to be on their own separate lines, this allows to check the rtc of `jq` to ensure that the platform is defined, and if it is not output a warning since some benchmarks may not need some dependencies (like pip packages).

# Before/After Comparison
## Before
Code would output this if a platform is not found
```
jq: error (at <filename>:26): null (null) cannot be csv-formatted, only array
```

## After
The following warning message will take it's place

```
WARN: Could not find dependency information for <OS> in <JSON file>, this could be intended behavior
```

# Clerical Stuff
This closes #98 

Relates to JIRA: RPOPC-651
