### PR TITLE
pkg_tool: Add SLES support

### DIFF
--- a/package_tool
+++ b/package_tool
@@ -169,6 +169,9 @@ case "$running_os" in
 	"ubuntu")
 		install_cmd="/bin/apt"
 	;;
+	"sles")
+		install_cmd="/usr/bin/zypper"
+	;;
 	*)
 		if [[ -f "/bin/dnf" ]]; then
 			install_cmd="/bin/dnf"


### PR DESCRIPTION
# Description
Add SLES support for installing packages.  Due to zypper install dumping to stdout, this should be blocked by PR #101.  Without that PR, zypper install dumps to stdout which is not caught and is passed directly to package_tool, which causes the first run on any system missing `wget` to fail.

# Before/After Comparison
## Before
SLES is not supported, and will error out not knowing what package manager to use.

## After
SLES is supported, and able to install packages.

# Clerical Stuff
This closes #102

Relates to JIRA: RPOPC-653