### PR TITLE
Add tar workflow on release

### DIFF
--- a/.github/workflows/package_on_release.yml
+++ b/.github/workflows/package_on_release.yml
@@ -1,0 +1,26 @@
+on:
+  release:
+    types:
+      - published
+
+jobs:
+  package_repo:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Package the needed files
+        run: >
+          tar -cf /tmp/test_tools.tar
+          --exclude ".github*"
+          --exclude ".git*" 
+          --exclude "tests/*"
+          .
+      
+      - name: Upload artifact to release
+        run: gh release upload ${{ github.event.release.tag_name }} /tmp/test_tools.tar
+        env:
+          GH_TOKEN: ${{ github.token }}


### PR DESCRIPTION
# Description
Adds a simple tar workflow once a release is cut.  The name of the tarball will be `test_tools.tar` and this will let us start versioning this repo.  Wrappers can start declaring what versions of test_tools-wrappers are required for their function.

# Before/After Comparison
## Before
This repo is unversioned and may require multiple packages to extract and use the tools in this repo.

## After
This repo is versioned and requires minimal packages (curl, tar) to extract and use the tools.

# Clerical Stuff

This closes #104 

Relates to JIRA: RPOPC-657
