### PR TITLE
pkg_tool: Add ability to install packages based off OS version

### DIFF
--- a/package_tool
+++ b/package_tool
@@ -257,11 +257,11 @@ fi
 if [[ -n "$wrapper_config" ]]; then
 	wrapper_pkgs=$(parse_json $wrapper_config $running_os)
 	if [[ $? -ne 0 ]]; then
-		exit 1
+		exit_out "Error parsing .dependencies.$running_os in $wrapper_config" 1
 	fi
 	wrapper_pip=$(parse_json $wrapper_config pip)
 	if [[ $? -ne 0 ]]; then
-		exit $?
+		exit_out "Error parsing .dependencies.pip in $wrapper_config" 1
 	fi
 	
 	packages=$(append_packages $packages $wrapper_pkgs)


### PR DESCRIPTION
# Description
This adds the ability for `package_tool` to install packages based off the OS version instead of solely the OS vendor.  This will not change the behavior of only having a list of packages for a vendor.

Additionally, the version number can be done via only a major (to cover stuff like the entirety of RHEL 9) or a major/minor version pair to handle specific versions if needed.

# Before/After Comparison
## Before
The wrapper_config can only differentiate based off the OS vendor.

## After
The wrapper_config can differentiate based off OS Vendor and OS version.

# Clerical Stuff
This closes #109 
Relates to JIRA: RPOPC-672
