### PR TITLE
package_tool Add ability to update system package cache

### DIFF
--- a/package_tool
+++ b/package_tool
@@ -9,6 +9,7 @@ usage()
 	echo "  --update: Update the system."
 	echo "  --usage: This usage message."
 	echo "  --pip_packages: comma separated list of pip modules to install"
+	echo "  --update_cache: Update package cache before install/updating packages, 1 (default) updates cache, 0 skips cache update"
 	echo "  --python_exec: path to python intrepreter to install pip modules for (default \"python3\"), will require installation of relevant packages to install pip"
 	exit 1
 }
@@ -27,9 +28,18 @@ remove_packages=""
 wrapper_config=""
 pip_packages=""
 python_exec="python3"
+update_cache=1
+cache_cmd=""
 
 base_dir=$(dirname $(realpath $0))
 running_os=$($base_dir/detect_os)
+
+update_system_cache() {
+	if [[ "$update_cache" -eq 1 ]]; then
+		$install_cmd $cache_cmd
+	fi
+	update_cache=0 # Prevent multiple cache updates
+}
 
 # Install System packages
 # Args:
@@ -41,7 +51,7 @@ install_system_pkgs() {
 	if [[ -z "$package_list" ]]; then
 		return 0 # Nothing to do
 	fi
-
+	update_system_cache
 	for package in $package_list; do
 		$install_cmd install -y $package
 		if [ $? -ne 0 ]; then
@@ -116,6 +126,7 @@ install_pip_pkgs() {
 ARGUMENT_LIST=(
 	"is_installed"
 	"no_packages"
+	"update_cache"
 	"packages"
 	"remove_packages"
 	"wrapper_config"
@@ -179,6 +190,10 @@ while [[ $# -gt 0 ]]; do
 			wrapper_config=$2
 			shift 2
 		;;
+		--update_cache)
+			update_cache=$2
+			shift 2
+		;;
 		-h)
 			usage $0
 		;;
@@ -196,9 +211,11 @@ install_cmd=""
 case "$running_os" in
 	"ubuntu")
 		install_cmd="/bin/apt"
+		cache_cmd="update"
 	;;
 	"sles")
 		install_cmd="/usr/bin/zypper"
+		cache_cmd="refresh"
 	;;
 	*)
 		if [[ -f "/bin/dnf" ]]; then
@@ -206,6 +223,7 @@ case "$running_os" in
 		elif [[ -f "/bin/yum" ]]; then
 			install_cmd="/bin/yum"
 		fi
+		cache_cmd="makecache"
 	;;
 esac
 


### PR DESCRIPTION
# Description
Adds the `--update_cache` option to allow/disallow system package manager cache updates.  By default, this option is enabled, and system package manager cache will be update once when installing packages.

# Before/After Comparison
## Before
System package manager cache would not be updated when running package_tool

## After
System package manager cache will be updated by default, but adding `--update_cache 0` will disable the cache updating.

# Clerical Stuff
Closes #119 
Relates to JIRA: RPOPC-692
