### PR TITLE
Add a path for package_tool

### DIFF
--- a/pcp/pcp_commands.inc
+++ b/pcp/pcp_commands.inc
@@ -55,7 +55,7 @@ setup_pcp()
 	# If pmlogger isn't present, install the PCP bits
 	pcp_present=$(which pmlogger)
 	if [[ $? -ne 0 ]]; then 
-		package_tool --packages pcp-zeroconf,pcp-pmda-openmetrics,pcp-pmda-denki
+		${TOOLS_BIN}/package_tool --packages pcp-zeroconf,pcp-pmda-openmetrics,pcp-pmda-denki
 	fi
 
 	working_dir="/usr/local/src/PCPrecord"


### PR DESCRIPTION
# Description
Adds a path for package_tool to pcp_commands

# Before/After Comparison
Before: package_tool couldn't be found since it's not in the path
After: We tell the script where to find package_tool

# Clerical Stuff
This closes #123 
Relates to JIRA: RPOPC-707
