### PR TITLE
feat(package_tool): Add CentOS as supported platform

### DIFF
--- a/deps/python_pip.json
+++ b/deps/python_pip.json
@@ -14,6 +14,9 @@
         ],
         "amzn": [
             "python3-pip"
+        ],
+        "centos": [
+            "python3-pip"
         ]
     }
 }


### PR DESCRIPTION
# Description
This PR adds the ability for CentOS to use `--pip_packages` from `package_tool`

# Before/After Comparison
## Before
Running `package_tool --pip_packages pydantic` would return the following error message
```
centos has no known python3-pip package
```

## After
`package_tool --pip_packages pydantic` works as expected

# Clerical Stuff
Issue #129 

Relates to JIRA: RPOPC-766