### PR TITLE
Abort if we have duplicate metric names.

### DIFF
--- a/pcp/pcp_commands.inc
+++ b/pcp/pcp_commands.inc
@@ -99,6 +99,17 @@ working_dir="/usr/local/src/PCPrecord"
 	else
 		cp ${TOOLS_BIN}/pcp/openmetrics_default_reset.txt /tmp/openmetrics_workload_reset.txt
 	fi
+	#
+	# Verify there are no duplicate records.
+	#
+	total_recs=`wc -l /tmp/openmetrics_workload_reset.txt | awk '{print $1}'`
+	uniq_recs=$(awk '{print $1}' /tmp/openmetrics_workload_reset.txt | sort -u | wc -l)
+	if [[ $total_recs -ne  $uniq_recs ]]; then
+		echo "ERROR: /tmp/openmetrics_workload_reset.txt contains duplicate metric names"
+		echo "Following are the dups"
+		awk '{print $1}' /tmp/openmetrics_workload_reset.txt | sort | uniq -d
+		exit 1
+	fi
 	# Stop and then Restart the service
 	systemctl stop PCPrecord.service
 	systemctl stop pmcd


### PR DESCRIPTION
# Description
If there are duplicate metrics in the pcp open metric file, flag it and abort.

# Before/After Comparison
Before:  If metrics are duplicated in openmetrics, it can have unexpected behavior.
After: If we have a duplicate metric in openmetrics, flag the duplicate and bail out with an error.

# Clerical Stuff
This closes #132 

Relates to JIRA: RPOPC-768

===================================
Test results

Command executed
/home/ec2-user/workloads/phoronix-wrapper-3.2/phoronix/run_phoronix.sh --run_user ec2-user --home_parent /home --iterations 1 --tuned_setting tuned_none_sys_file_ --host_config "m7i.xlarge" --sysname "m7i.xlarge" --sys_type aws  --use_pcp --sub_test redis

====================================
PCP Output

====================================
Note pcp is not fully in for phoronix, so this is just an example, may not contain 100% valid data

          o.w.SET  o.w.SADD  o.w.LPUSH  o.w.LPOP  o.w.Average  o.w.ParallelConnections  o.w.GET  o.w.running  o.w.iteration  o.w.iteration0  o.w.running0  o.w.numthreads0  o.w.runtimeNaN  o.w.throughputNaN  o.w.latencyNaN  o.w.GETNaN  o.w.LPOPNaN  o.w.LPUSHNaN  o.w.SADDNaN  o.w.SETNaN  o.w.ParallelConnectionsNaN  o.w.AverageNaN
17:36:34    0.000     0.000      0.000     0.000  2543454.530                 1000.000    0.000        0.000          1.000             NaN           N/A              NaN             NaN                NaN             NaN         NaN          NaN           NaN          NaN         NaN                         NaN             NaN

=======================================
csv output (successful run)
======================================
Test:Connections:Average
GET:50:3103671.92
SET:50:2535425.68
GET:500:3086248.35
LPOP:50:2285615.90
SADD:50:2754768.00
SET:500:2486144.57
GET:1000:3011040.42
LPOP:500:2375004.42
LPUSH:50:2244240.00
SADD:500:2800068.67
SET:1000:2543454.53
LPOP:1000:2354114.83
LPUSH:500:2208423.57
SADD:1000:2860262.27
LPUSH:1000:2251246.31

================================
output with a duplicate metric entry
===============================
ERROR: /tmp/openmetrics_workload_reset.txt contains duplicate metric names
Following are the dups
iteration

================================
-x output from wrapper success
================================

[redis_x.txt](https://github.com/user-attachments/files/24723190/redis_x.txt)
