### PR TITLE
Replace single metric update with ability to set multiple metric updates

### DIFF
--- a/pcp/pcp_commands.inc
+++ b/pcp/pcp_commands.inc
@@ -138,6 +138,9 @@ stop_pcp()
 #Sends value to OpenMetrics file to be added to PCP archive
 #$1: metric
 #$2: value
+# Note:
+#	result2pcp is depreicated, and will be going away, use results2pcp_multiple
+#	instead.
 result2pcp()
 {
 	echo "Logging results ${1} ${2}"
@@ -220,7 +223,7 @@ results2pcp_multiple()
 			echo "Warning: Unexpected metric, ${metric}, being logged. Check for a typo."
 		fi
 		value=`echo $i | cut -d':' -f2`
-                sed -i "s/^${metric} .*$/${metric} ${value}/" /tmp/openmetrics_workload_worker
+		sed -i "s/^${metric} .*$/${metric} ${value}/" /tmp/openmetrics_workload_worker
 	done
 	#
 	# Now cat it to be recorded, do not copy it or move it file.


### PR DESCRIPTION

# Description
Introduces the following functions to pcp
results2pcp_multiple
results2pcp_add_value
results2pcp_add_value_commit

which replaces
result2pcp

# Before/After Comparison
Before:
   Only one metric at a time is written out to pcp.  This results in the situation where a test that has multiple metrics
   the results are scattered across multiple lines.
After:
   All the metrics are written at once as far as pcp is concern, making it so all lines reporting that particular set of data
   metrics, have all the metrics set.

# Clerical Stuff
This closes #130 

Relates to JIRA: RPOPC-767

===================================
Test results
===================================
Command executed
/home/ec2-user/workloads/specjbb_pcp/specjbb/specjbb_run --run_user ec2-user --home_parent /home --iterations 1 --tuned_setting tuned_none_sys_file_ --host_config m7i.xlarge --sysname m7i.xlarge --sys_type aws --use_pcp

PCP results
          o.w.iteration  o.w.running  o.w.numthreads  o.w.runtime  o.w.throughput  o.w.latency  o.w.Warehouse  o.w.BOPs
21:56:17          0.000        1.000           0.000          NaN             NaN          NaN          2.000  215244.0
21:56:18          0.000        1.000           0.000          NaN             NaN          NaN          2.000  215244.0
21:56:19          0.000        1.000           0.000          NaN             NaN          NaN          4.000  264917.0
21:56:20          0.000        1.000           0.000          NaN             NaN          NaN          4.000  264917.0
21:56:21          0.000        1.000           0.000          NaN             NaN          NaN          6.000  260161.0
21:56:22          0.000        1.000           0.000          NaN             NaN          NaN          6.000  260161.0
21:56:23          0.000        1.000           0.000          NaN             NaN          NaN          8.000  255219.0
21:56:24          0.000        1.000           0.000          NaN             NaN          NaN          8.000  255219.0

csv output
Warehouses:Bops
2:217015
4:265312
6:264362
8:260559

x output from wrapper success

[pcp_multiple.txt](https://github.com/user-attachments/files/24736145/pcp_multiple.txt)

