### PR TITLE
feat(general_setup): Add --debug flag

### DIFF
--- a/general_setup
+++ b/general_setup
@@ -51,6 +51,7 @@ source ~/.bashrc
 gs_usage_info()
 {
 	echo "General options"
+	echo "  --debug: Enables bash -x output, useful for debugging issues with wrappers"
 	echo "  --home_parent <value>: Our parent home directory.  If not set, defaults to current working directory."
 	echo "  --host_config <value>: default is the current host name."
 	echo "  --iterations <value>: Number of times to run the test, defaults to 1."
@@ -70,7 +71,6 @@ gs_usage_info()
 	echo "    RHEL systems, default is none."
 	echo "  --usage: this usage message."
 	echo "  --use_pcp: Enables use of Performance Co-Pilot in wrappers, defaults to 0."
-	echo "  --debug: Enables bash -x output, useful for debugging issues with wrappers"
 	exit 1
 }
 


### PR DESCRIPTION
# Description
Adds `--debug` flag which will initiate `bash -x` output when running a wrapper.

# Before/After Comparison
## Before
Manual editing was sometimes required when running wrappers to get `bash -x` output.

## After
The wrapper can now receive `--debug` to see `bash -x` trace output.

# Clerical Stuff
This closes #135

Relates to JIRA: RPOPC-777

Output of `./coremark-wrapper/coremark/coremark_run --debug`
[coremark.log](https://github.com/user-attachments/files/24778895/coremark.log)