### PR TITLE
fix(pcp): Explicitly start pmcd, remove After from service

### DIFF
--- a/pcp/PCPrecord.service
+++ b/pcp/PCPrecord.service
@@ -1,7 +1,6 @@
 [Unit]
 Description=PCP Recorder
 
-After=pmcd.service
 [Service]
 Type=notify
 WorkingDirectory=/usr/local/src/PCPrecord

--- a/pcp/pcp_commands.inc
+++ b/pcp/pcp_commands.inc
@@ -125,6 +125,7 @@ working_dir="/usr/local/src/PCPrecord"
 	systemctl daemon-reload
 	sleep 1
 	# WHY is this issuing warning to run 'systemctl daemon-reload'?
+	systemctl start pmcd
 	systemctl start PCPrecord.service # This will start pmcd and wait for openme
 	sleep 1
 }


### PR DESCRIPTION
# Description
When doing multiple runs, for some reason using After=pmcd.service does not start pmcd but instead starts and then terminates the process.  This moves back to an explict `systemctl start pmcd` and then starts PCPrecord.

# Before/After Comparison
## Before
Running `setup_pcp` in a wrapper after the first time would end up timing out and exiting with an error.

## After
Everything works normally, pmcd starts and allows PCPrecord to work properly.

This was verified by running `coremark` 10 times back-to-back.
# Clerical Stuff
Closes #140 

Relates to JIRA: RPOPC-793

## `bash -x` run
[coremark.log](https://github.com/user-attachments/files/24869765/coremark.log)

## `pmrep` output
[coremark_pmrep.txt](https://github.com/user-attachments/files/24869788/coremark_pmrep.txt)