### PR TITLE
Copy the private openmetrics to /tmp if defined.

### DIFF
--- a/pcp/pcp_commands.inc
+++ b/pcp/pcp_commands.inc
@@ -158,6 +158,7 @@ working_dir="/usr/local/src/PCPrecord"
 		cp ${TOOLS_BIN}/pcp/openmetrics_default_reset.txt /tmp/openmetrics_workload_reset.txt
 	fi
 	openmetrics_file_verification /tmp/openmetrics_workload_reset.txt
+	cp /tmp/openmetrics_workload_reset.txt /tmp/openmetrics_workload.txt
 	# Stop and then Restart the service
 	systemctl stop PCPrecord.service
 	systemctl stop pmcd


### PR DESCRIPTION
# Description
Reinserts the copying of the private openmetrics

# Before/After Comparison
Before: We dropped the copying of the private openmetrics.  Missed because the testing was done on system that had an existing openmetrics
After: We copy the openmetrics to /tmp

# Clerical Stuff
This closes #144 

JIRA: RPOPC-803
