### PR TITLE
Break helper functions out of general_setup

### DIFF
--- a/general_setup
+++ b/general_setup
@@ -45,29 +45,6 @@ source ~/.bashrc
 # to_no_pkg_install: Test is not to use dnf/yum/apt or other such tools
 
 #
-# Standard time stamp for outputting to the csv files
-#
-retrieve_time_stamp()
-{
-	date -u "+%Y-%m-%dT%H:%M:%SZ"
-}
-
-#
-# Build the string and filter out all , in the results values
-#
-build_data_string()
-{
-	out_string=""
-	separ=""
-	for arg in "$@"; do
-		append=`echo $arg | sed "s/,//g"`
-		out_string=${out_string}${separ}${append}
-		separ=","
-	done
-	echo $out_string
-}
-
-#
 # Present usage information.
 #
 
@@ -281,7 +258,5 @@ fi
 if [ $to_times_to_run -eq 0 ]; then
 	to_times_to_run=$iteration_default
 fi
+source $TOOLS_BIN/helpers.inc
 set $gen_args_back
-
-test_start_time=$(retrieve_time_stamp)
-export test_start

--- a/helpers.inc
+++ b/helpers.inc
@@ -1,0 +1,43 @@
+#
+# Copyright (C) 2026  David Valin dvalin@redhat.com
+#
+# This program is free software; you can redistribute it and/or
+# modify it under the terms of the GNU General Public License
+# as published by the Free Software Foundation; either version 2
+# of the License, or (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; if not, write to the Free Software
+# Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+#
+
+#
+# Standard time stamp for outputting to the csv files
+#
+retrieve_time_stamp()
+{
+	date -u "+%Y-%m-%dT%H:%M:%SZ"
+}
+
+#
+# Build the string and filter out all , in the results values
+#
+build_data_string()
+{
+	out_string=""
+	separ=""
+	for arg in "$@"; do
+		append=`echo $arg | sed "s/,//g"`
+		out_string=${out_string}${separ}${append}
+		separ=","
+	done
+	echo $out_string
+}
+
+test_start_time=$(retrieve_time_stamp)
+export test_start


### PR DESCRIPTION
# Description
Moves the helper functions in general_setup to be in helpers.inc

# Before/After Comparison
Before:   Issue with the layered wrappers, where we will not be able to see those functions, and if we source general_setup again, it overwrites all the globals on us (as expected)
After: Can access the helper functions now via source helpers.inc without resetting prior values set in general_setup.


# Clerical Stuff
This closes #146 

Relates to JIRA: RPOPC-804

Testing
Command executed:
/home/ec2-user/workloads/coremark-wrapper/coremark/coremark_run --run_user ec2-user --home_parent /home --iterations 1 --tuned_setting tuned_none_sys_file_ --host_config "m7i.2xlarge" --sysname "m7i.2xlarge" --sys_type aws  --iterations 1 --use_pcp

Also test with linpack which uses layered wrappers.  Works fine there.
So verified we did not break the wrappers that do not call a sub wrapper, and the issues fixes the actual proble,

csv_file
iteration,threads,IterationsPerSec,Start_Date,End_Date
1,8,157248.157248,2026-01-28T12:53:33Z,2026-01-28T12:54:20Z
1,8,162684.290798,2026-01-28T12:53:33Z,2026-01-28T12:54:20Z

pcp
         o.w.iteration  o.w.running  o.w.numthreads  o.w.runtime  o.w.throughput  o.w.latency  o.w.runlog  o.w.IterationsPerSec
12:54:21          1.000        1.000           8.000          NaN             NaN          NaN       1.000            162684.291
12:54:22          1.000        1.000           8.000          NaN             NaN          NaN       1.000            162684.291
12:54:25          1.000        0.000           8.000          NaN             NaN          NaN       2.000            157248.157
12:54:26          1.000        0.000           8.000          NaN             NaN          NaN       2.000            157248.157

-x output
[coremark_out.txt](https://github.com/user-attachments/files/24911360/coremark_out.txt)
