### PR TITLE
feat(general_setup): Pass new package flags to package tool

### DIFF
--- a/general_setup
+++ b/general_setup
@@ -104,7 +104,7 @@ to_tuned_setting=""
 to_use_pcp=0
 
 package_tool() {
-	$TOOLS_BIN/package_tool $to_pkg_tool_flags $@
+	"${TOOLS_BIN}/package_tool" ${to_pkg_tool_flags} "$@"
 }
 
 i=1


### PR DESCRIPTION
### **User description**
# Description
Adds support for `--no_system_packages` and `--no_pip_packages` which
can be passed to `package_tool`.  This also adds a convience function
that provides all the relevant flags set by `general_setup` (mainly
`--no_packages` and the new `--no_*_packages` flags) to reduce duplicate
code snippets.

This will not break previous uses of direct calls to `package_tool` or
usage of `to_no_pkg_install`.

# Before/After Comparison
## Before
Only `--no_packages` was allowed, turning off any kind of package installation

## After
`--no_system_packages` and `--no_pip_packages` are added, allowing more selective package installations.

# Clerical Stuff
Closes #148

Relates to JIRA: RPOPC-813

[no_pip_pkgs.txt](https://github.com/user-attachments/files/24945553/no_pip_pkgs.txt)
[no_pkg_install.txt](https://github.com/user-attachments/files/24945554/no_pkg_install.txt)
[no_sys_pkgs.txt](https://github.com/user-attachments/files/24945555/no_sys_pkgs.txt)
[normal_run.txt](https://github.com/user-attachments/files/24945556/normal_run.txt)

___

### **PR Type**
Enhancement


___

### **Description**
- Add granular package installation flags for selective control

- Introduce `--no_system_packages` and `--no_pip_packages` options

- Pass new flags to package tool via `to_pkg_tool_flags` variable

- Update usage documentation to reflect new package control options


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Command line args"] -->|"--no_system_packages<br/>--no_pip_packages"| B["to_pkg_tool_flags"]
  B -->|"Append to"| C["to_no_pkg_install"]
  C -->|"Pass to"| D["package_tool"]
  E["--no_pkg_install"] -->|"Legacy option"| C
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>general_setup</strong><dd><code>Add selective package installation control flags</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

general_setup

<ul><li>Updated usage documentation to describe three distinct package control <br>options<br> <li> Added <code>to_pkg_tool_flags</code> variable to accumulate new package-related <br>flags<br> <li> Implemented argument parsing for <code>--no_system_packages</code> and <br><code>--no_pip_packages</code> flags<br> <li> Appended <code>to_pkg_tool_flags</code> to <code>to_no_pkg_install</code> for passing to package <br>tool</ul>


</details>


  </td>
  <td><a href="https://github.com/redhat-performance/test_tools-wrappers/pull/149/files#diff-6ea6bbce87100e3cf102288489ab67b635d931d3a615e456ebab9546f2dbec3e">+10/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

