### PR TITLE
When a command is not found, trap it, and exit out with an error code…

### DIFF
--- a/general_setup
+++ b/general_setup
@@ -71,10 +71,11 @@ handle_usr1_trap()
 
 trap 'handle_usr1_trap' USR1 INT
 #
-# The command_not_found_handle function is activated when a command executing cannot be located.
+# The command_not_found_handle function is activated when BASH cannot find a BASH cannot find a command
+# in $PATH.
 #
 # Since this function operates within a subshell of the caller, a simple exit would only return an
-# exit code to the calling shell, which is insufficient. The desired behavior is for the calling shell
+# exit code to the subshell, which is insufficient. The desired behavior is for the calling shell
 # to terminate immediately, returning the correct exit code to the command line.
 #
 # To achieve this, the function first saves the return code (rtc) to a temporary file named exit_with_<pid>.


### PR DESCRIPTION

# DescriptionWhen a command is not found, trap it, and exit out with an error code 127

# Before/After Comparison
Before:  A missing command would simply spit a message to the screen and keep running.
After:  A missing command will result in a message being spit out, and the script exiting with an error code 127.

# Clerical Stuff
This closes #155 

Relates to JIRA: RPOPC-838

Testing

Command executed
exec /home/ec2-user/workloads/coremark-wrapper-testing/coremark/coremark_run --run_user ec2-user --home_parent /home --iterations 1 --tuned_setting tuned_none_sys_file_ --host_config "m7i.xlarge" --sysname "m7i.xlarge" --sys_type aws  --use_pcp --iterations 1

Successful run:
Dependencies resolved.
Nothing to do.
Complete!
Start PCP
PCP metrics reset
PCP Start Complete
PCP metrics reset
Starting PCP subset
Link performed along with compile
Loading done ./coremark.exe
Loading done ./coremark.exe
Check run1.log and run2.log for results.
See readme.txt for run and reporting rules.
PCP metrics reset
PCP metrics reset
Stopping PCP subset
Stop PCP
Results verified
updating: results_coremark_virtual-guest.tar (deflated 88%)
[root@ip-170-0-19-107 ec2-user]# echo $?
0

CSV file
iteration,threads,IterationsPerSec,Start_Date,End_Date
1,4,79908.105678,2026-02-16T16:23:33Z,2026-02-16T16:24:20Z
1,4,80442.433384,2026-02-16T16:23:33Z,2026-02-16T16:24:20Z

Failed run
WARNING: Running pip as the 'root' user can result in broken permissions and conflicting behaviour with the system package manager. It is recommended to use a virtual environment instead: https://pip.pypa.io/warnings/venv
WARNING: Running pip as the 'root' user can result in broken permissions and conflicting behaviour with the system package manager. It is recommended to use a virtual environment instead: https://pip.pypa.io/warnings/venv
/home/ec2-user/workloads/coremark-wrapper-testing/coremark
Error: The command "bad_command" was not found.
[root@ip-170-0-19-107 ec2-user]# echo $?
127

output of bad run from --debug option
[coremark_debug.txt](https://github.com/user-attachments/files/25346003/coremark_debug.txt)
[coremark_debug.txt](https://github.com/user-attachments/files/25346003/coremark_debug.txt)

