### PR TITLE
Fix save_results so --copy_dir is working.

### DIFF
--- a/save_results
+++ b/save_results
@@ -217,14 +217,13 @@ pushd $export_results > /dev/null
 copy_file ${curdir}/meta_data*.yml ${RESULTS_PATH}
 copy_file ${curdir}/hw_info.out ${RESULTS_PATH}
 
+copy_file ${results_dir}/*  ${RESULTS_PATH}
+pushd $export_results > /dev/null
 tar hcf results_${test_name}_${tuned_setting}.tar ${results_dir}
-copy_file ${results_dir}/* .
-link_files results_${test_name}_${tuned_setting}.tar results_pbench_${test_name}_${tuned_setting}.tar
-tardir=`pwd`
-link_files ${tardir}/results_${test_name}_${tuned_setting}.tar /tmp/results_${test_name}_${tuned_setting}.tar
-link_files ${tardir}/results_${test_name}_${tuned_setting}.tar /tmp/results_pbench_${test_name}_${tuned_setting}.tar
-
+mv results_${test_name}_${tuned_setting}.tar /tmp
+popd > /dev/null
 cd /tmp
+
 #
 # Provide a common pull for Zathra.
 #
@@ -232,5 +231,4 @@ if [[ -f  test_wrapper_results_${test_name}.zip ]]; then
 	rm test_wrapper_results_${test_name}.zip
 fi
 zip results_${test_name}.zip  results_${test_name}_${tuned_setting}.tar
-link_files results_${test_name}.zip results_pbench_${test_name}.zip
 popd > /dev/null


### PR DESCRIPTION
# Description
The directories designated by --copy_dir are not appearing in the tar ball.  Noticed with speccpu2017 pcp results

# Before/After Comparison
Before: pcp directory for speccpu2017 not appearing in tar ball.
After: pcp directory for speccpu2017 is in the tar ball.

# Clerical Stuff
This closes #157 

Relates to JIRA: RPOPC-843

Testing

Command executed
/home/ec2-user/workloads/speccpu2017-wrapper/speccpu2017/run_speccpu --run_user ec2-user --home_parent /home --iterations 1 --tuned_setting tuned_none_sys_file_ --host_config "m7i.2xlarge" --sysname "m7i.2xlarge" --sys_type aws  --use_pcp --disks grab_disks --test 500.perlbench_r


csv file
Benchmarks,Base copies,Base Run Time,Base Rate,Start_Date,End_Date
500.perlbench_r,8,413,30.9,2026-02-19T13:32:18Z,2026-02-19T13:39:17Z
502.gcc_r,,,,NR,2026-02-19T13:32:18Z,2026-02-19T13:39:17Z
505.mcf_r,,,,NR,2026-02-19T13:32:18Z,2026-02-19T13:39:17Z
520.omnetpp_r,,,,NR,2026-02-19T13:32:18Z,2026-02-19T13:39:17Z
523.xalancbmk_r,,,,NR,2026-02-19T13:32:18Z,2026-02-19T13:39:17Z
525.x264_r,,,,NR,2026-02-19T13:32:18Z,2026-02-19T13:39:17Z
531.deepsjeng_r,,,,NR,2026-02-19T13:32:18Z,2026-02-19T13:39:17Z
541.leela_r,,,,NR,2026-02-19T13:32:18Z,2026-02-19T13:39:17Z
548.exchange2_r,,,,NR,2026-02-19T13:32:18Z,2026-02-19T13:39:17Z
557.xz_r,,,,NR,2026-02-19T13:32:18Z,2026-02-19T13:39:17Z

Before change pcp directory not in the tar ball.

After change pcp directroy is in the tar ball
[root@ip-170-0-27-175 tmp]# tar xvf results_speccpu2017_virtual-guest.tar
speccpu2017_2026.02.19-13.39.26/
speccpu2017_2026.02.19-13.39.26/tuned_setting
speccpu2017_2026.02.19-13.39.26/results_speccpu_virtual-guest_2026.02.19-13.39.26/
speccpu2017_2026.02.19-13.39.26/results_speccpu_virtual-guest_2026.02.19-13.39.26/result/
speccpu2017_2026.02.19-13.39.26/results_speccpu_virtual-guest_2026.02.19-13.39.26/result/lock.CPU2017
speccpu2017_2026.02.19-13.39.26/results_speccpu_virtual-guest_2026.02.19-13.39.26/result/CPU2017.001.log
speccpu2017_2026.02.19-13.39.26/results_speccpu_virtual-guest_2026.02.19-13.39.26/result/CPU2017.002.log
speccpu2017_2026.02.19-13.39.26/results_speccpu_virtual-guest_2026.02.19-13.39.26/result/CPU2017.002.intrate.refrate.results.csv
speccpu2017_2026.02.19-13.39.26/results_speccpu_virtual-guest_2026.02.19-13.39.26/result/CPU2017.002.intrate.refrate.rsf
speccpu2017_2026.02.19-13.39.26/results_speccpu_virtual-guest_2026.02.19-13.39.26/result/CPU2017.002.intrate.refrate.flags.html
speccpu2017_2026.02.19-13.39.26/results_speccpu_virtual-guest_2026.02.19-13.39.26/result/CPU2017.002.intrate.refrate.orig.cfg
speccpu2017_2026.02.19-13.39.26/results_speccpu_virtual-guest_2026.02.19-13.39.26/result/CPU2017.002.intrate.refrate.cfg
speccpu2017_2026.02.19-13.39.26/results_speccpu_virtual-guest_2026.02.19-13.39.26/result/CPU2017.002.intrate.refrate.csv
speccpu2017_2026.02.19-13.39.26/results_speccpu_virtual-guest_2026.02.19-13.39.26/result/CPU2017.002.intrate.refrate.pdf
speccpu2017_2026.02.19-13.39.26/results_speccpu_virtual-guest_2026.02.19-13.39.26/result/invalid.gif
speccpu2017_2026.02.19-13.39.26/results_speccpu_virtual-guest_2026.02.19-13.39.26/result/CPU2017.002.intrate.refrate.html
speccpu2017_2026.02.19-13.39.26/results_speccpu_virtual-guest_2026.02.19-13.39.26/result/CPU2017.002.intrate.refrate.txt
speccpu2017_2026.02.19-13.39.26/results_speccpu_virtual-guest_2026.02.19-13.39.26/speccpu2017.out
speccpu2017_2026.02.19-13.39.26/results_speccpu_virtual-guest_2026.02.19-13.39.26/test_results_report
speccpu2017_2026.02.19-13.39.26/pcp_2026.02.19-13.32.11/
speccpu2017_2026.02.19-13.39.26/pcp_2026.02.19-13.32.11/speccpu_500.perlbench_r.log
speccpu2017_2026.02.19-13.39.26/pcp_2026.02.19-13.32.11/speccpu_500.perlbench_r.index
speccpu2017_2026.02.19-13.39.26/pcp_2026.02.19-13.32.11/speccpu_500.perlbench_r.meta
speccpu2017_2026.02.19-13.39.26/pcp_2026.02.19-13.32.11/speccpu_500.perlbench_r.0
speccpu2017_2026.02.19-13.39.26/pcp_2026.02.19-13.32.11/meta_data_0.yml

