### PR TITLE
Add ability to select a specific test_tools release

### DIFF
--- a/general_setup
+++ b/general_setup
@@ -296,12 +296,12 @@ done
 export to_sys_env
 
 if [[ $test_tools_release != "" ]]; then
-	new_td=${HOME}/test_tools_${test_tools_release}
+	new_td="${HOME}/test_tools_${test_tools_release}"
 
-	if [[ ! -d $new_td ]]; then
-		git clone https://github.com/redhat-performance/test_tools-wrappers $new_td
-		pushd $new_td > /dev/null
-		git checkout tags/$test_tools_release
+	if [[ ! -d "$new_td" ]]; then
+		git clone https://github.com/redhat-performance/test_tools-wrappers "$new_td"
+		pushd "$new_td" > /dev/null
+		git "checkout tags/$test_tools_release"
 		if [[ $? -ne 0 ]]; then
 			echo "Error test_tools-wrappers tag $test_tools_release is unknown"
 			exit 1


### PR DESCRIPTION
# Description
Adds the ability to use a specific test_tools release

# Before/After Comparison
Before:  Only used the latest release
After:  Can use a designated release

# Clerical Stuff
This closes #159 

Relates to JIRA: RPOPC-848

Testing done

Ran the coremark wrapper
1) Verified if no release is designated we use the latest pull
2) Verified that if we designated a release, we could pull the proper release and use it (See debug.txt)

debug.txt
[debug.txt](https://github.com/user-attachments/files/25607557/debug.txt)
