### PR TITLE
Add pcp packaging

### DIFF
--- a/pcp/pcp.json
+++ b/pcp/pcp.json
@@ -1,5 +1,9 @@
 {
   "dependencies": {
+    "amzn": [
+      "spal-release",
+      "pcp-zeroconf"
+    ],
     "rhel": [
       "pcp-zeroconf",
       "pcp-pmda-openmetrics",


### PR DESCRIPTION
# Description
Add pcp packaging for amazon 2023

# Before/After Comparison
Before: We would fail on running a wrapper wanting pcp on amazon2023
After:  Test now runs.

# Clerical Stuff
This closes #167 

Relates to JIRA: RPOPC-858

Testing:
Verified that the wrapper running pcp now runs on amazon 2023 without any errors about pcp not being present.
