### PR TITLE
Move package tool

### DIFF
--- a/general_setup
+++ b/general_setup
@@ -30,7 +30,6 @@ if [[ $TOOLS_BIN == "" ]]; then
 	TOOLS_BIN=$(realpath $(dirname $0))
 fi
 source ${TOOLS_BIN}/error_codes
-source $TOOLS_BIN/helpers.inc
 
 # Values setting for test wrappers to use.
 #
@@ -346,6 +345,7 @@ if [[ $test_tools_release != "" ]]; then
 	#
 	TOOLS_BIN=$new_td
 fi
+source $TOOLS_BIN/helpers.inc
 
 export to_sys_env
 if [[ ! -d $TOOLS_BIN ]]; then

--- a/general_setup
+++ b/general_setup
@@ -30,6 +30,7 @@ if [[ $TOOLS_BIN == "" ]]; then
 	TOOLS_BIN=$(realpath $(dirname $0))
 fi
 source ${TOOLS_BIN}/error_codes
+source $TOOLS_BIN/helpers.inc
 
 # Values setting for test wrappers to use.
 #
@@ -188,10 +189,6 @@ to_os_running=""
 
 export to_no_pkg_install
 export to_os_running
-
-package_tool() {
-	"${TOOLS_BIN}/package_tool" ${to_pkg_tool_flags} "$@"
-}
 
 i=1
 j=$#
@@ -382,5 +379,4 @@ fi
 if [ $to_times_to_run -eq 0 ]; then
 	to_times_to_run=$iteration_default
 fi
-source $TOOLS_BIN/helpers.inc
 set $gen_args_back

--- a/helpers.inc
+++ b/helpers.inc
@@ -17,6 +17,19 @@
 #
 
 #
+# Only source this once.
+#
+
+if [[ -n "$HELPERS_SOURCED" ]]; then
+	return 0 # Already sourced, no need to do it again
+fi
+#
+# Set it only, not export.  If we export it, then any scripts that are called
+# that need the contents of this file, will not have it.
+#
+HELPERS_SOURCED=true
+
+#
 # Standard time stamp for outputting to the csv files
 #
 retrieve_time_stamp()

--- a/helpers.inc
+++ b/helpers.inc
@@ -20,14 +20,14 @@
 # Only source this once.
 #
 
-if [[ -n "$HELPERS_SOURCED" ]]; then
+if [[ -n "$__TEST_TOOLS_HELPERS_SOURCED" ]]; then
 	return 0 # Already sourced, no need to do it again
 fi
 #
 # Set it only, not export.  If we export it, then any scripts that are called
 # that need the contents of this file, will not have it.
 #
-HELPERS_SOURCED=true
+__TEST_TOOLS_HELPERS_SOURCED=true
 
 #
 # Standard time stamp for outputting to the csv files

--- a/helpers.inc
+++ b/helpers.inc
@@ -41,3 +41,8 @@ build_data_string()
 
 test_start_time=$(retrieve_time_stamp)
 export test_start_time
+
+package_tool() {
+	"${TOOLS_BIN}/package_tool" ${to_pkg_tool_flags} "$@"
+}
+

--- a/pcp/pcp_commands.inc
+++ b/pcp/pcp_commands.inc
@@ -16,6 +16,7 @@
 # Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
 #
 
+source ${TOOLS_BIN}/helpers.inc
 gl_metric_list=""
 gl_metric_separ=""
 FIFO="/tmp/pcpFIFO"
@@ -111,7 +112,7 @@ setup_pcp()
 	# to the screen.
 	which pmlogger > /dev/null 2>&1
 	if [[ $? -ne 0 ]]; then 
-		${TOOLS_BIN}/package_tool --no_packages $to_no_pkg_install --wrapper_config ${TOOLS_BIN}/pcp/pcp.json
+		package_tool --wrapper_config ${TOOLS_BIN}/pcp/pcp.json
 	fi
 	# Distro-specific magic required once the packages are installed
 	running_os=`${TOOLS_BIN}/detect_os`


### PR DESCRIPTION
# Description
Moves package_tool from general_setup to helpers.inc. 

# Before/After Comparison
Before:  We were not able to access package_tool in a wrapper that has multiple bash scripts it calls.  Doing so would mess up various environmental variables, plus there is the issue of rerunning code we already executed.
After:  We are able to source helpers.inc as many times as we want without impacting anything, thus making the package_tool function available to all scripts.

# Clerical Stuff
This closes #179 

RPOPC-921

Testing Information

Ran it with an updated hammerdb (which uses subscripts), everything works fine, and produced the expected results

CSV generated
connection,TPM,Start_Date,End_Date
10,776722,2026-04-08T10:41:31Z,2026-04-08T10:58:34Z
20,1369258,2026-04-08T10:58:44Z,2026-04-08T11:15:52Z
40,1241927,2026-04-08T11:16:02Z,2026-04-08T11:33:10Z

