### PR TITLE
Add option to convert value to output floating point.

### DIFF
--- a/convert_val
+++ b/convert_val
@@ -235,7 +235,6 @@ else
 fi
 if [[ ${no_unit} == 0 ]]; then
 	printf "${to_unit}\n"
-else
-	printf "\n"
 fi
+printf "\n"
 exit $E_SUCCESS

--- a/convert_val
+++ b/convert_val
@@ -228,16 +228,14 @@ else
 	cnv_value=`echo "${scale}(${value}*${time_base_unit})/$time_cnvt_to" | bc ${float}`
 fi
 
-#
-# bc does not provide leading 0, which causes problems later.
-#
-zero_front=""
-if [[ ${cnv_value} == "."* ]]; then
-	zero_front="0"
+if [[ $float != "" ]]; then
+	printf "%0.9f" "${cnv_value}"
+else
+	printf "%d" "${cnv_value}"
 fi
 if [[ ${no_unit} == 0 ]]; then
-	echo ${zero_front}${cnv_value}${to_unit}
+	printf "${to_unit}\n"
 else
-	echo ${zero_front}${cnv_value}
+	printf "\n"
 fi
 exit $E_SUCCESS

--- a/convert_val
+++ b/convert_val
@@ -20,6 +20,10 @@
 #
 # Convert various time and memory units.
 
+float=""
+scale=""
+no_unit=0
+
 if [[ $TOOLS_BIN == "" ]]; then
 	TOOLS_BIN=$(realpath $(dirname $0))
 fi
@@ -31,6 +35,8 @@ usage()
 	echo "usage $1 <unit>"
 	echo "-h --help --usage: This help message"
 	echo "--value <value>: Value to be converted."
+	echo "--float:  Output is a floating point number.."
+	echo "--no_unit:  Do not print the unit."
 	echo "--from_unit <u>: Unit of value to be converted"
 	echo "  Default K if --time_val is not specified, otherwise ns"
 	echo "--time_val: Units being worked with are time vals"
@@ -66,7 +72,9 @@ if [[ $1 == "" ]]; then
 fi
 
 NOARG_OPTS=(
+	"float"
 	"help"
+	"no_unit"
 	"time_val"
 	"usage"
 )
@@ -105,8 +113,17 @@ time_val=0
 
 while [[ $# -gt 0 ]]; do
 	case "$1" in
+		--float)
+			float="-l"
+			scale="scale=9;"
+			shift 1
+		;;
 		-h | --usage | --help)
 			usage $0
+		;;
+		--no_unit)
+			no_unit="1"
+			shift 1
 		;;
 		--to_unit)
 			to_unit=$2
@@ -200,15 +217,27 @@ cnvt_unit_to_nsec()
 	fi
 }
 
+cnv_value=""
 if [ $time_val -eq 0 ]; then
 	cnvt_to_bytes $from_unit to_base_unit
 	cnvt_to_bytes $to_unit converting_to
-	cnv_value=`echo \(${value}*${to_base_unit}\)/$converting_to | bc`
-	echo ${cnv_value}${to_unit}
+	cnv_value=`echo "${scale}(${value}*${to_base_unit})/$converting_to" | bc ${float}`
 else
 	cnvt_unit_to_nsec $from_unit time_base_unit
 	cnvt_unit_to_nsec $to_unit time_cnvt_to
-	cnv_value=`echo \(${value}*${time_base_unit}\)/$time_cnvt_to | bc`
-	echo ${cnv_value}${to_unit}
+	cnv_value=`echo "${scale}(${value}*${time_base_unit})/$time_cnvt_to" | bc ${float}`
+fi
+
+#
+# bc does not provide leading 0, which causes problems later.
+#
+zero_front=""
+if [[ ${cnv_value} == "."* ]]; then
+	zero_front="0"
+fi
+if [[ ${no_unit} == 0 ]]; then
+	echo ${zero_front}${cnv_value}${to_unit}
+else
+	echo ${zero_front}${cnv_value}
 fi
 exit $E_SUCCESS


### PR DESCRIPTION
# Description
Adds two options to convert_val
1) --float  tells convert_val to output the value in floating point, 9 place decimal (handles nano seconds then), with a leading 0 before the decimal point
2) --no_unit  tells convert_val do not put a unit on the output.  For those wrappers that know the unit, it saves a call to sed to strip it off.

# Before/After Comparison
Before:  Output was whole numbers only.
After: Output using the --float option will be a floating point number.

# Clerical Stuff
This closes #184 

Mention the JIRA ticket of the issue, this helps keep 
everything together so we can find this PR easily.

Relates to JIRA: RPOPC-1034

Testing:
$ ./convert_val --time_val --from_unit ns --to_unit secs --value 12345 --float 
0.000012345secs
$ ./convert_val --time_val --from_unit ns --to_unit secs --value 12345 --float --no_unit
0.000012345
$ ./convert_val --time_val --from_unit ns --to_unit secs --value 12345
0secs

