### PR TITLE
Remove pbench args and mentions

### DIFF
--- a/general_setup
+++ b/general_setup
@@ -20,11 +20,7 @@
 # This file is contains code that is common among the test wrappers.
 #
 
-#
-# Source .bashrc to keep pbench happy.
-# 
 test_cmd=$0
-source ~/.bashrc
 
 if [[ $TOOLS_BIN == "" ]]; then
 	TOOLS_BIN=$(realpath $(dirname $0))
@@ -37,10 +33,6 @@ source ${TOOLS_BIN}/error_codes
 # to_home_root: home directory
 # to_configuration: configuration information
 # to_times_to_run: number of times to run the test
-# to_pbench: Run the test via pbench
-# to_pbench_copy: Copy the pbench data, not move it.
-# to_puser: User running pbench
-# to_pstats: pbench stats to use
 # to_run_label: Label for the run
 # to_user: User on the test system running the test
 # to_sys_type: for results info, basically aws, azure or local
@@ -139,11 +131,7 @@ gs_usage_info()
 	echo "  --no_system_packages: Do not install system packages via the system package manager"
 	echo "  --no_pip_packages: Do not install python pip packages via pip"
 	echo "  --no_pkg_install: Test is not to install any packages"
-	echo "  --pbench: use pbench-user-benchmark and place information into pbench, defaults to do not use."
-	echo "  --pbench_user <value>: user who started everything. Defaults to the current user."
-	echo "  --pbench_copy: Copy the pbench data, not move it."
-	echo "  --pbench_stats: What stats to gather. Defaults to all stats."
-	echo "  --run_label: the label to associate with the pbench run. No default setting."
+	echo "  --run_label: the label to associate with the run. No default setting."
 	echo "  --run_user: user that is actually running the test on the test system. Defaults to user running wrapper."
 	echo "  --sys_type: Type of system working with, aws, azure, hostname.  Defaults to hostname."
 	echo "  --test_tools_release <tag>: Version tag of test tools to use"
@@ -166,17 +154,13 @@ to_script_dir=`dirname $(realpath $0)`
 if [[ $to_home_root == "" ]]; then
 	to_home_root="/"
 fi
-to_pbench=0
-to_pbench_copy="0"
 
-to_puser=`whoami`
 to_run_user=`whoami`
 to_times_to_run=0
 iteration_default=1
 to_run_label=""
 to_user=`whoami`
 to_sysname=`hostname`
-to_pstats="default"
 export to_pkg_tool_flags=""
 to_no_pkg_install=0
 skip_verification=0
@@ -235,26 +219,6 @@ do
 			i=$((i+1))
 			to_pkg_tool_flags="$1=1 $to_pkg_tool_flags"
 			shift 1
-		;;
-		--pbench)
-			to_pbench=1
-			i=$((i + 1))
-			shift 1
-		;;
-		--pbench_copy)
-			to_pbench_copy=1
-			i=$((i + 1))
-			shift 1
-		;;
-		--pbench_stats)
-			i=$((i + 2))
-			to_pstats=$value
-			shift 2
-		;;
-		--pbench_user)
-			i=$((i + 2))
-			to_puser=$value
-			shift 2
 		;;
 		--run_label)
 			i=$((i + 2))


### PR DESCRIPTION
# Description
This removes all pbench arguments as it is no longer supported by Zathras.

Any configuration files will need to remove the use of these arguments or at least avoid going down code paths that do use them.

# Before/After Comparison
## Before
`--pbench*` options are available but will inevitably lead to broken functionality

## After
The options are removed to prevent problems and broken functionality.

# Clerical Stuff
Issue #187 

Relates to JIRA: RPOPC-1216