### PR TITLE
Add support for azurelinux

### DIFF
--- a/deps/python_pip.json
+++ b/deps/python_pip.json
@@ -3,6 +3,9 @@
         "rhel": [
             "python3-pip"
         ],
+        "azurelinux": [
+            "python3-pip"
+        ],
         "ubuntu": [
             "python3-pip"
         ],

--- a/pcp/pcp.json
+++ b/pcp/pcp.json
@@ -9,6 +9,11 @@
       "pcp-pmda-openmetrics",
       "pcp-pmda-denki"
     ],
+    "azurelinux": [
+      "pcp-zeroconf",
+      "pcp-pmda-openmetrics",
+      "pcp-pmda-denki"
+    ],
     "sles": [
       "pcp-zeroconf",
       "pcp-pmda-openmetrics"


### PR DESCRIPTION
# Description
Updates the packaging in test_tools to support azurelinux

# Before/After Comparison
Before: Failures on several different installations.
After: Installation works fine.


# Clerical Stuff
This closes #189 

Relates to JIRA: RPOPC-1251

Testing:

With updated coremark-wrapper packaging and before updating test tools packaging
Updating and loading repositories:
Repositories loaded.
Package Arch   Version       Repository           Size
Installing:
 bc     x86_64 1.08.2-3.azl4 azurelinux-base 232.5 KiB

Transaction Summary:
 Installing:         1 package

Total size of inbound packages is 124 KiB. Need to download 124 KiB.
After this operation, 233 KiB extra will be used (install 233 KiB, remove 0 B).
[1/1] bc-0:1.08.2-3.azl4.x86_64         100% | 733.0 KiB/s | 123.9 KiB |  00m00s
--------------------------------------------------------------------------------
[1/1] Total                             100% | 728.7 KiB/s | 123.9 KiB |  00m00s
Running transaction
[1/3] Verify package files              100% |   1.0 KiB/s |   1.0   B |  00m00s
[2/3] Prepare transaction               100% |  25.0   B/s |   1.0   B |  00m00s
[3/3] Installing bc-0:1.08.2-3.azl4.x86 100% |   1.9 MiB/s | 236.0 KiB |  00m00s
Complete!
Updating and loading repositories:
Repositories loaded.
Package  Arch   Version       Repository           Size
Installing:
 numactl x86_64 2.0.19-4.azl4 azurelinux-base 157.4 KiB

Transaction Summary:
 Installing:         1 package

Total size of inbound packages is 70 KiB. Need to download 70 KiB.
After this operation, 157 KiB extra will be used (install 157 KiB, remove 0 B).
[1/1] numactl-0:2.0.19-4.azl4.x86_64    100% | 328.3 KiB/s |  70.3 KiB |  00m00s
--------------------------------------------------------------------------------
[1/1] Total                             100% | 328.3 KiB/s |  70.3 KiB |  00m00s
Running transaction
[1/3] Verify package files              100% |   1.0 KiB/s |   1.0   B |  00m00s
[2/3] Prepare transaction               100% |  30.0   B/s |   1.0   B |  00m00s
[3/3] Installing numactl-0:2.0.19-4.azl 100% | 588.6 KiB/s | 161.3 KiB |  00m00s
Complete!
Updating and loading repositories:
Repositories loaded.
Package Arch   Version          Repository           Size
Installing:
 perf   x86_64 6.18.31-1.5.azl4 azurelinux-base  11.9 MiB

Transaction Summary:
 Installing:         1 package

Total size of inbound packages is 3 MiB. Need to download 3 MiB.
After this operation, 12 MiB extra will be used (install 12 MiB, remove 0 B).
[1/1] perf-0:6.18.31-1.5.azl4.x86_64    100% |   9.5 MiB/s |   2.7 MiB |  00m00s
--------------------------------------------------------------------------------
[1/1] Total                             100% |   9.5 MiB/s |   2.7 MiB |  00m00s
Running transaction
[1/3] Verify package files              100% |  71.0   B/s |   1.0   B |  00m00s
[2/3] Prepare transaction               100% |  45.0   B/s |   1.0   B |  00m00s
[3/3] Installing perf-0:6.18.31-1.5.azl 100% |  38.0 MiB/s |  12.0 MiB |  00m00s
Complete!
Updating and loading repositories:
Repositories loaded.
Package "unzip-6.0-68.azl4.x86_64" is already installed.

Nothing to do.
Updating and loading repositories:
Repositories loaded.
Package Arch   Version         Repository           Size
Installing:
 make   x86_64 1:4.4.1-12.azl4 azurelinux-base   1.8 MiB

Transaction Summary:
 Installing:         1 package

Total size of inbound packages is 579 KiB. Need to download 579 KiB.
After this operation, 2 MiB extra will be used (install 2 MiB, remove 0 B).
[1/1] make-1:4.4.1-12.azl4.x86_64       100% |   1.2 MiB/s | 578.9 KiB |  00m00s
--------------------------------------------------------------------------------
[1/1] Total                             100% |   1.2 MiB/s | 578.9 KiB |  00m00s
Running transaction
[1/3] Verify package files              100% | 250.0   B/s |   1.0   B |  00m00s
[2/3] Prepare transaction               100% |  31.0   B/s |   1.0   B |  00m00s
[3/3] Installing make-1:4.4.1-12.azl4.x 100% |   8.1 MiB/s |   1.8 MiB |  00m00s
Complete!
Updating and loading repositories:
Repositories loaded.
Package "sed-4.9-6.azl4.x86_64" is already installed.

Nothing to do.
Updating and loading repositories:
Repositories loaded.
Package "gawk-5.3.2-3.azl4.x86_64" is already installed.

Nothing to do.
Updating and loading repositories:
Repositories loaded.
Package          Arch   Version          Repository           Size
Installing:
 gcc             x86_64 15.2.1-7.azl4    azurelinux-base 112.0 MiB
Installing dependencies:
 binutils        x86_64 2.45.1-5.azl4    azurelinux-base  27.3 MiB
 cpp             x86_64 15.2.1-7.azl4    azurelinux-base  38.0 MiB
 glibc-devel     x86_64 2.42-10.azl4     azurelinux-base   2.3 MiB
 kernel-headers  x86_64 6.18.31-1.1.azl4 azurelinux-base   6.8 MiB
 libmpc          x86_64 1.3.1-9.azl4     azurelinux-base 160.6 KiB
 libxcrypt-devel x86_64 4.5.2-3.azl4     azurelinux-base  31.1 KiB

Transaction Summary:
 Installing:         7 packages

Total size of inbound packages is 61 MiB. Need to download 61 MiB.
After this operation, 187 MiB extra will be used (install 187 MiB, remove 0 B).
[1/7] binutils-0:2.45.1-5.azl4.x86_64   100% |   8.5 MiB/s |   5.9 MiB |  00m01s
[2/7] glibc-devel-0:2.42-10.azl4.x86_64 100% | 386.6 KiB/s | 490.6 KiB |  00m01s
[3/7] cpp-0:15.2.1-7.azl4.x86_64        100% |   6.3 MiB/s |  12.9 MiB |  00m02s
[4/7] libxcrypt-devel-0:4.5.2-3.azl4.x8 100% | 173.0 KiB/s |  30.6 KiB |  00m00s
[5/7] libmpc-0:1.3.1-9.azl4.x86_64      100% | 163.1 KiB/s |  70.8 KiB |  00m00s
[6/7] kernel-headers-0:6.18.31-1.1.azl4 100% |   3.3 MiB/s |   1.6 MiB |  00m00s
[7/7] gcc-0:15.2.1-7.azl4.x86_64        100% |   9.2 MiB/s |  39.6 MiB |  00m04s
--------------------------------------------------------------------------------
[7/7] Total                             100% |  14.0 MiB/s |  60.6 MiB |  00m04s
Running transaction
[1/9] Verify package files              100% |  23.0   B/s |   7.0   B |  00m00s
[2/9] Prepare transaction               100% | 137.0   B/s |   7.0   B |  00m00s
[3/9] Installing libmpc-0:1.3.1-9.azl4. 100% |  12.2 MiB/s | 162.1 KiB |  00m00s
[4/9] Installing cpp-0:15.2.1-7.azl4.x8 100% | 281.3 MiB/s |  38.0 MiB |  00m00s
[5/9] Installing kernel-headers-0:6.18. 100% | 100.6 MiB/s |   6.9 MiB |  00m00s
[6/9] Installing glibc-devel-0:2.42-10. 100% |  58.8 MiB/s |   2.4 MiB |  00m00s
[7/9] Installing libxcrypt-devel-0:4.5. 100% |   1.2 MiB/s |  33.4 KiB |  00m00s
[8/9] Installing binutils-0:2.45.1-5.az 100% | 187.5 MiB/s |  27.4 MiB |  00m00s
[9/9] Installing gcc-0:15.2.1-7.azl4.x8 100% |  61.2 MiB/s | 112.0 MiB |  00m02s
Complete!
Updating and loading repositories:
Repositories loaded.
Package "git-2.53.0-2.azl4.x86_64" is already installed.

Nothing to do.
Updating and loading repositories:
Repositories loaded.
Package Arch   Version     Repository           Size
Installing:
 zip    x86_64 3.0-45.azl4 azurelinux-base 694.5 KiB

Transaction Summary:
 Installing:         1 package

Total size of inbound packages is 262 KiB. Need to download 262 KiB.
After this operation, 695 KiB extra will be used (install 695 KiB, remove 0 B).
[1/1] zip-0:3.0-45.azl4.x86_64          100% | 835.7 KiB/s | 262.4 KiB |  00m00s
--------------------------------------------------------------------------------
[1/1] Total                             100% | 833.0 KiB/s | 262.4 KiB |  00m00s
Running transaction
[1/3] Verify package files              100% | 500.0   B/s |   1.0   B |  00m00s
[2/3] Prepare transaction               100% |  30.0   B/s |   1.0   B |  00m00s
[3/3] Installing zip-0:3.0-45.azl4.x86_ 100% |   5.2 MiB/s | 698.4 KiB |  00m00s
Complete!
cp: cannot create regular file '/var/lib/pcp/pmdas/openmetrics/config.d/': No such file or directory
Warning: The unit file, source configuration file or drop-ins of PCPrecord.service changed on disk. Run 'systemctl daemon-reload' to reload units.
Failed to stop pmcd.service: Unit pmcd.service not loaded.
Failed to start pmcd.service: Unit pmcd.service not found.
Start PCP
PCP metrics reset
PCP Start Complete
Timed out waiting 2 sec for systemd status=READY:           Request=

**After updating packaging in test_tools**

Complete!
Warning: The unit file, source configuration file or drop-ins of PCPrecord.service changed on disk. Run 'systemctl daemon-reload' to reload units.
Start PCP
PCP metrics reset
PCP Start Complete
PCP metrics reset
Starting PCP subset
Link performed along with compile
Loading done ./coremark.exe
Loading done ./coremark.exe
Check run1.log and run2.log for results.
See readme.txt for run and reporting rules.
PCP metrics reset
PCP metrics reset
Stopping PCP subset
PCP metrics reset
Starting PCP subset
Link performed along with compile
Loading done ./coremark.exe
Loading done ./coremark.exe
Check run1.log and run2.log for results.
See readme.txt for run and reporting rules.
PCP metrics reset
PCP metrics reset
Stopping PCP subset
PCP metrics reset
Starting PCP subset
Link performed along with compile
Loading done ./coremark.exe
Loading done ./coremark.exe
Check run1.log and run2.log for results.
See readme.txt for run and reporting rules.
PCP metrics reset
PCP metrics reset
Stopping PCP subset
PCP metrics reset
Starting PCP subset
Link performed along with compile
Loading done ./coremark.exe
Loading done ./coremark.exe
Check run1.log and run2.log for results.
See readme.txt for run and reporting rules.
PCP metrics reset
PCP metrics reset
Stopping PCP subset
PCP metrics reset
Starting PCP subset
Link performed along with compile
Loading done ./coremark.exe
Loading done ./coremark.exe
Check run1.log and run2.log for results.
See readme.txt for run and reporting rules.
PCP metrics reset
PCP metrics reset
Stopping PCP subset
Stop PCP
Results verified
  adding: results_coremark_tuned_none.tar (deflated 92%)

CSV file
iteration,threads,IterationsPerSec,Start_Date,End_Date
1,16,284684.844980,2026-06-03T15:11:19Z,2026-06-03T15:12:13Z
1,16,285739.798196,2026-06-03T15:11:19Z,2026-06-03T15:12:13Z
2,16,286366.280370,2026-06-03T15:12:27Z,2026-06-03T15:13:20Z
2,16,287047.003947,2026-06-03T15:12:27Z,2026-06-03T15:13:20Z
3,16,284532.965812,2026-06-03T15:13:35Z,2026-06-03T15:14:28Z
3,16,287072.755001,2026-06-03T15:13:35Z,2026-06-03T15:14:28Z
4,16,284153.975936,2026-06-03T15:14:42Z,2026-06-03T15:15:36Z
4,16,285752.556146,2026-06-03T15:14:42Z,2026-06-03T15:15:36Z
5,16,282249.173098,2026-06-03T15:15:50Z,2026-06-03T15:16:44Z
5,16,287072.755001,2026-06-03T15:15:50Z,2026-06-03T15:16:44Z
